### PR TITLE
update SDRplay api to 3.15.2 to support the RSPdxR2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -55,6 +55,8 @@ SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 COPY --from=build /dump1090 /usr/bin/dump1090
 
+COPY install_sdrplay.sh /tmp/install_sdrplay.sh
+
 RUN set -x && \
     #
     echo "TARGETPLATFORM $TARGETPLATFORM" && \
@@ -75,7 +77,6 @@ RUN set -x && \
     #
     # Install the SDRPlay driver
     mkdir -p /etc/udev/rules.d/ && \
-    curl --location --output /tmp/install_sdrplay.sh https://raw.githubusercontent.com/sdr-enthusiasts/docker-sdrplay-beast1090/main/install_sdrplay.sh && \
     chmod +x /tmp/install_sdrplay.sh && \
     /tmp/install_sdrplay.sh && \
     # Add Container Version

--- a/install_sdrplay.sh
+++ b/install_sdrplay.sh
@@ -4,7 +4,7 @@
 ARCH=`uname -m`
 OSDIST="Unknown"
 
-VERS="3.14"
+VERS="3.15"
 MAJVERS="3"
 
 if [ -f "/etc/os-release" ]; then
@@ -33,7 +33,14 @@ if [ "${ARCH}" != "aarch64" ] && [ "$ARCH" != "x86_64" ]; then
     echo "Unsupported ARCH. Exiting..."
     exit 1
 else
-    URL="https://www.sdrplay.com/software/SDRplay_RSP_API-Linux-3.14.0.run"
+    URL="https://www.sdrplay.com/software/SDRplay_RSP_API-Linux-3.15.2.run"
+fi
+
+# Override arch install dir for x86_64, as SDRPlay is now storing those binaries in the amd64 dir,
+# not the x86_64 dir. aarch64 is still in the aarch64 dir
+ARCH_DIR="${ARCH}"
+if [ "${ARCH}" == "x86_64" ] ; then
+    ARCH_DIR="amd64"
 fi
 
 # Below is an adaptation of the install script from the SDRPlay website
@@ -81,7 +88,7 @@ mkdir -p ${INSTALLBINDIR} || exit 1
 
 echo -n "Installing ${INSTALLLIBDIR}/libsdrplay_api.so.${VERS}..."
 rm -f ${INSTALLLIBDIR}/libsdrplay_api.so.${VERS} || exit 1
-cp -f ${ARCH}/libsdrplay_api.so.${VERS} ${INSTALLLIBDIR}/. || exit 1
+cp -f ${ARCH_DIR}/libsdrplay_api.so.${VERS} ${INSTALLLIBDIR}/. || exit 1
 chmod 644 ${INSTALLLIBDIR}/libsdrplay_api.so.${VERS} || exit 1
 rm -f ${INSTALLLIBDIR}/libsdrplay_api.so.${MAJVERS} || exit 1
 ln -s ${INSTALLLIBDIR}/libsdrplay_api.so.${VERS} ${INSTALLLIBDIR}/libsdrplay_api.so.${MAJVERS} || exit 1
@@ -95,7 +102,7 @@ chmod 644 ${INSTALLINCDIR}/sdrplay_api*.h || exit 1
 echo "Done"
 
 echo -n "Installing API Service in ${INSTALLBINDIR}..."
-cp -f ${ARCH}/sdrplay_apiService ${INSTALLBINDIR}/sdrplay_apiService  || exit 1
+cp -f ${ARCH_DIR}/sdrplay_apiService ${INSTALLBINDIR}/sdrplay_apiService  || exit 1
 chmod 755 ${INSTALLBINDIR}/sdrplay_apiService || exit 1
 echo "Done"
 


### PR DESCRIPTION
Hello,

Thanks for your work on this project.  I was trying to connect my sdrplay RSPdxR2 with ultrafeeder
and the container wasn't able to detect it, so I got it working and I just wanted to share the fix
with you.

Currently the container has the SDRPlay 3.14 api, which unfortunately doesn't support the RSPdxR2.
RSPdxR2 support requires API 3.15 or later [0]. The path in the installer tar was changed
to /amd64 instead of /x86_64, so I also had to update that.

Once I upgraded the SDRplay API version it was able to connect to my RSDPdxR2,
and read the data to feed into ultrafeeder. No other changes were needed.

I also changed the Dockerfile to copy copy the install_sdrplay.sh from the repo directly for my dev work,
I think that makes more sense than redownloading it from github, but I can revert it back to the curl
command if that's your preference.

0: https://www.sdrplay.com/api/