### PR TITLE
chore(flake/precommit): `a994d570` -> `58a5f530`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -98,11 +98,11 @@
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1786105217,
-        "narHash": "sha256-ySp0dc1E9ZorICTvG1467QKzZYCp0fcBECEeycz3Dtw=",
+        "lastModified": 1787294166,
+        "narHash": "sha256-MSchJhtWP+KQMRUlVC1AuPQItpdn3wtFoeuVdLhdbvk=",
         "owner": "FredSystems",
         "repo": "pre-commit-checks",
-        "rev": "a994d570247f1d80cbbcd8a33c4b4f866e16af87",
+        "rev": "58a5f5309274af48b6611cafd506383a227d7d61",
         "type": "github"
       },
       "original": {
@@ -122,11 +122,11 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1786076960,
-        "narHash": "sha256-jfR6OhwurCKn1tREyfOcK/Omxf1Q/DzDDFbnEr1mBLs=",
+        "lastModified": 1787281715,
+        "narHash": "sha256-5yIL5XL31hCZBPWDdUOvUy4cYAl27XZrke7JELhHlnI=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "57a23bfaf4f7017267294b161175db1e32eb1c85",
+        "rev": "89abdfd661ea493cde2f73d7b1332cb34150aa43",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                                         | Message                                               |
| -------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------- |
| [`58a5f530`](https://github.com/fredsystems/pre-commit-checks/commit/58a5f5309274af48b6611cafd506383a227d7d61) | `` chore(flake/rust-overlay): c84e121a -> 89abdfd6 `` |
| [`40049176`](https://github.com/fredsystems/pre-commit-checks/commit/40049176bd78e79a84322502e11770db8e042e1f) | `` chore(flake/nixpkgs): 0e251e24 -> ffb3c9b7 ``      |
| [`724249bf`](https://github.com/fredsystems/pre-commit-checks/commit/724249bfc4773b7a6640ec1fe78d324dd7ca965c) | `` chore(flake/rust-overlay): f1dcc7e4 -> c84e121a `` |
| [`42c10474`](https://github.com/fredsystems/pre-commit-checks/commit/42c10474772f46184668827c86ed97fc7fbd3fb3) | `` chore(flake/rust-overlay): 892c035d -> f1dcc7e4 `` |
| [`edd622fd`](https://github.com/fredsystems/pre-commit-checks/commit/edd622fddbac6968ee7185e28abb3a7b9bc289f1) | `` update flake inputs ``                             |