### PR TITLE
chore(flake/nixpkgs): `f13ff45a` -> `56c02bc0`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -58,11 +58,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1786106723,
-        "narHash": "sha256-zDSUbpoeo/9ZmD2+wXnzxoo1+uhL8vxc0b8yuYMKYq0=",
+        "lastModified": 1787498568,
+        "narHash": "sha256-9i/VTdusq/+NM/tz+J1Re+ojkMB8MBf0QshnYfzHz30=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "f13ff45afd1bb73e640eaa08a7066dbed07e3238",
+        "rev": "56c02bc00adcf003215cc4bd996d6efaf4cff188",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                          |
| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------ |
| [`83f0616a`](https://github.com/NixOS/nixpkgs/commit/83f0616a5b55e30691ab589915c10707811ad826) | `` quill-log: 12.1.0 -> 12.2.0 ``                                                                |
| [`4aced058`](https://github.com/NixOS/nixpkgs/commit/4aced058857460113edf80e7c046568fc65c84aa) | `` gnome-desktop: replace systemd dependency with systemdLibs ``                                 |
| [`cae01058`](https://github.com/NixOS/nixpkgs/commit/cae010589188d10480046a3fd855a7f6d10b3ba8) | `` proxify: add nix-update-script ``                                                             |
| [`f8baccac`](https://github.com/NixOS/nixpkgs/commit/f8baccacfce34eddcc934aa885c30b40fe94cdcc) | `` proxify: add versionCheckHook ``                                                              |
| [`6c5e687a`](https://github.com/NixOS/nixpkgs/commit/6c5e687a6dc35a9827bd8f0e80458d54e37779ee) | `` proxify: modernize ``                                                                         |
| [`7cb6379f`](https://github.com/NixOS/nixpkgs/commit/7cb6379f3f0dba8ea8ddcef3e569e2f808ca18ba) | `` chaos: add nix-update-script ``                                                               |
| [`c71d9fec`](https://github.com/NixOS/nixpkgs/commit/c71d9fec13665992f24ad26c22362f06835417b4) | `` python3Packages.aioeagle: migrate to finalAttrs ``                                            |
| [`d9fccf5b`](https://github.com/NixOS/nixpkgs/commit/d9fccf5bcad816221824ecd99b44900d84342e2d) | `` openrisk: add nix-update-script ``                                                            |
| [`b949a306`](https://github.com/NixOS/nixpkgs/commit/b949a306b2d6e1c6a2f460233a7948b891e72b3e) | `` openrisk: modernize ``                                                                        |
| [`022ee2ed`](https://github.com/NixOS/nixpkgs/commit/022ee2ed20b8682e8d187d27a5d7c3846718b122) | `` urlfinder: add nix-update-script ``                                                           |
| [`085c1c7c`](https://github.com/NixOS/nixpkgs/commit/085c1c7c41ed47947572f6180c82f4ee6625cbbd) | `` urlfinder: add versionCheckHook ``                                                            |
| [`9057ef7f`](https://github.com/NixOS/nixpkgs/commit/9057ef7f8556418c730e4ce6027d1ca889781327) | `` urlfinder: modernize ``                                                                       |
| [`0838cd0f`](https://github.com/NixOS/nixpkgs/commit/0838cd0f89a1a40bfd86f1bf47d53b549b83cf12) | `` uncover: add nix-update-script ``                                                             |
| [`e20236b3`](https://github.com/NixOS/nixpkgs/commit/e20236b3cdc9a6c793bfc7fba36a3202209bdd77) | `` alterx: add nix-update-script ``                                                              |
| [`31bce446`](https://github.com/NixOS/nixpkgs/commit/31bce446646e4734692634806d3021f47db3b7ee) | `` alterx: add versionCheckHook ``                                                               |
| [`00c7888f`](https://github.com/NixOS/nixpkgs/commit/00c7888f3d14d6ddb68c7dae62d7fed43c5911e1) | `` alterx: add ldflags ``                                                                        |
| [`96bc1a0d`](https://github.com/NixOS/nixpkgs/commit/96bc1a0d035606a832e0f6b44ca2fd26028a6d6c) | `` asnmap: add nix-update-script ``                                                              |
| [`009bcd0f`](https://github.com/NixOS/nixpkgs/commit/009bcd0ffd51fbe848488439cef8e4d2368e1b2b) | `` asnmap: add versionCheckHook ``                                                               |
| [`ac685524`](https://github.com/NixOS/nixpkgs/commit/ac6855248eebdc945189217236341aefd87e3c93) | `` asnmap: modernize ``                                                                          |
| [`c1606384`](https://github.com/NixOS/nixpkgs/commit/c16063842e2be202931c3f9a91ceb7eade971e6c) | `` vulnx: add nix-update-script ``                                                               |
| [`e15c7892`](https://github.com/NixOS/nixpkgs/commit/e15c78924691f181cd30fb3c07cb83acd679e711) | `` vulnx: enable versionCheckHook ``                                                             |
| [`fbea15c1`](https://github.com/NixOS/nixpkgs/commit/fbea15c19b7927337b7c4fc0195dad16ee940ccf) | `` terraform-providers.hashicorp_null: 3.3.0 -> 3.3.1 ``                                         |
| [`f1a43355`](https://github.com/NixOS/nixpkgs/commit/f1a433559f6ccd9d57df988fe6647dab34f3a670) | `` oha: 1.15.0 -> 1.16.0 ``                                                                      |
| [`00694595`](https://github.com/NixOS/nixpkgs/commit/00694595a222f09eff073598cef84a905f953514) | `` evcc: 0.314.2 -> 0.314.3 ``                                                                   |
| [`c55fd193`](https://github.com/NixOS/nixpkgs/commit/c55fd193fe66ee8952cf679d4349a370fce6b43d) | `` pixi: 0.76.2 -> 0.77.0 ``                                                                     |
| [`563c2fb0`](https://github.com/NixOS/nixpkgs/commit/563c2fb0dd128d096f11bbd75346e17f02507517) | `` flutter_rust_bridge_codegen: 2.12.0 -> 2.13.0 ``                                              |
| [`e1e62b9b`](https://github.com/NixOS/nixpkgs/commit/e1e62b9bbaae96ce1fc5dfec610aa0a61f46764a) | `` python3Packages.aioeagle: 1.1.0 -> 1.1.1 ``                                                   |
| [`e3951d93`](https://github.com/NixOS/nixpkgs/commit/e3951d937ef2b84fd823f910264b6ddb98e0da39) | `` python3Packages.otpauth: 2.2.1 -> 2.2.2 ``                                                    |
| [`7d044e38`](https://github.com/NixOS/nixpkgs/commit/7d044e385e234ba3bccecd250bd8f883df1e4b6c) | `` nuclei: add nix-update-script ``                                                              |
| [`3c45a4e2`](https://github.com/NixOS/nixpkgs/commit/3c45a4e2de19edc24443dea7781ad951e26e68ef) | `` nuclei: add __structuredAttrs ``                                                              |
| [`33eba10d`](https://github.com/NixOS/nixpkgs/commit/33eba10dc8c1fbff91070d68b3ad717612b777df) | `` naabu: add __structuredAttrs ``                                                               |
| [`8f6f9cfd`](https://github.com/NixOS/nixpkgs/commit/8f6f9cfdb8c8096496537f33ae1c2f8ba5261082) | `` naabu: add nix-update-script ``                                                               |
| [`b62c89af`](https://github.com/NixOS/nixpkgs/commit/b62c89affcd62ababdf062c879912b3221321679) | `` terraform-providers.digitalocean_digitalocean: 2.99.1 -> 2.100.0 ``                           |
| [`de0c1d06`](https://github.com/NixOS/nixpkgs/commit/de0c1d06822604238b678b9d9dd423275585b5f1) | `` mapcidr: add nix-update-script ``                                                             |
| [`f319e444`](https://github.com/NixOS/nixpkgs/commit/f319e444d967d2b4c46364ae5f1e900582cfbce5) | `` mapcidr: add versionCheckHook ``                                                              |
| [`c856c5f9`](https://github.com/NixOS/nixpkgs/commit/c856c5f99f20790cfc02b4be14f0d702f26c5c41) | `` katana: add nix-update-script ``                                                              |
| [`2b10432a`](https://github.com/NixOS/nixpkgs/commit/2b10432a11efb327438ddea952567eee0cbc06ec) | `` katana: add __structuredAttrs ``                                                              |
| [`574e1266`](https://github.com/NixOS/nixpkgs/commit/574e1266eb0a0393e24578acde394b2f26f12c1d) | `` httpx: add nix-update-script ``                                                               |
| [`3e510995`](https://github.com/NixOS/nixpkgs/commit/3e510995b06a6d136cd8276546046f5de6c90f80) | `` httpx: add   __structuredAttrs ``                                                             |
| [`18ebb49e`](https://github.com/NixOS/nixpkgs/commit/18ebb49e890128f9c24ca2e51987bb5a982fd82b) | `` mapcidr: modernize ``                                                                         |
| [`2a600b0d`](https://github.com/NixOS/nixpkgs/commit/2a600b0dda2b5db03595fd83d6b20eb033236418) | `` kdePackages.marknote: 1.4.1 -> 1.6.0 ``                                                       |
| [`9cd72d03`](https://github.com/NixOS/nixpkgs/commit/9cd72d039372c1dd870b828112461ed517c8d70c) | `` kdePackages: restore metadata for more due-to-be-deleted X11 stuff ``                         |
| [`cc50827f`](https://github.com/NixOS/nixpkgs/commit/cc50827fa05c86bfe31ff7a10e7a8bfa669205b2) | `` chaos: modernize ``                                                                           |
| [`8399fa19`](https://github.com/NixOS/nixpkgs/commit/8399fa1909d34454ae1dea165d67c68e806edcac) | `` subfinder: add __structuredAttrs ``                                                           |
| [`2940a923`](https://github.com/NixOS/nixpkgs/commit/2940a9236c89d74bfb8a91a504a357c21cf17287) | `` subfinder: add nix-update-script ``                                                           |
| [`f72bd25c`](https://github.com/NixOS/nixpkgs/commit/f72bd25c40878d0dcfe934a5ad6a28dba94c112e) | `` subfinder: add versionCheckHook ``                                                            |
| [`8de64eab`](https://github.com/NixOS/nixpkgs/commit/8de64eabc6db7797e2b7aa03f619e6623df437b7) | `` tlsx: add __structuredAttrs ``                                                                |
| [`97402c55`](https://github.com/NixOS/nixpkgs/commit/97402c55d60a6fecaca0dcfb9ef2fa6e6464d0e2) | `` nixos/kmscon: enforce that at least one monospace font exists ``                              |
| [`4b5a668c`](https://github.com/NixOS/nixpkgs/commit/4b5a668c607c8c3bad9eaedc30141b055cd5bfa3) | `` tlsx: add nix-update-script ``                                                                |
| [`354b3cd5`](https://github.com/NixOS/nixpkgs/commit/354b3cd5ddfb354244180559a87682569e687fcc) | `` tlsx: add versionCheckHook ``                                                                 |
| [`5432058e`](https://github.com/NixOS/nixpkgs/commit/5432058e6faf64e9917f8fdf006a95f6d753a3a0) | `` tldfinder: add versionCheckHook ``                                                            |
| [`d49438c2`](https://github.com/NixOS/nixpkgs/commit/d49438c2ba0ed43bc7a8f0117c6332494df3e776) | `` cloudlist: modernize ``                                                                       |
| [`a2bf923d`](https://github.com/NixOS/nixpkgs/commit/a2bf923d5dc5e214b92dc13119191b89e456a576) | `` gcx: 1.0.0 -> 1.1.0 ``                                                                        |
| [`72d73e7f`](https://github.com/NixOS/nixpkgs/commit/72d73e7ff50575041450913e2fb0dee09cffb490) | `` httpx: remove obsolete ldflags entry ``                                                       |
| [`520a0c08`](https://github.com/NixOS/nixpkgs/commit/520a0c08e92f7bc65c14953366ecd9b21df5f632) | `` nuclei: remove obsolete ldflags entry ``                                                      |
| [`5f10c121`](https://github.com/NixOS/nixpkgs/commit/5f10c121c0db2a1ef67013001cc2e7dd559add3e) | `` naabu: modernize ``                                                                           |
| [`7d13a3d9`](https://github.com/NixOS/nixpkgs/commit/7d13a3d9ca9cd1228ef2cbcf7afd96ca33a19a88) | `` katana: add versionCheckHook ``                                                               |
| [`393661af`](https://github.com/NixOS/nixpkgs/commit/393661af28713060acd316243831bbdc07f3bf58) | `` nix-eval-jobs: 2.35.1 -> 2.35.2 ``                                                            |
| [`1c0d906a`](https://github.com/NixOS/nixpkgs/commit/1c0d906a78f40e2f57c796e81f05fe6e1dcb6296) | `` python3Packages.pyisbn: migrate to finalAttrs ``                                              |
| [`9bee9e36`](https://github.com/NixOS/nixpkgs/commit/9bee9e362d3488df6819a83ae225c5f80f316631) | `` python3Packages.pyisbn: 1.3.1 -> 1.4.3 ``                                                     |
| [`60d1e6fd`](https://github.com/NixOS/nixpkgs/commit/60d1e6fd7dc9af8b678a6a1589f61adbfc5440dc) | `` discourse: fix eval on unsupported systems ``                                                 |
| [`d680a94e`](https://github.com/NixOS/nixpkgs/commit/d680a94e70ba95b4f72a26ae543384e6e15e145a) | `` python3Packages.pytelegrambotapi: 4.33.0 -> 4.36.1 ``                                         |
| [`81de8ac8`](https://github.com/NixOS/nixpkgs/commit/81de8ac83a81e10bbfd3f10f4665d6a350033b9a) | `` python3Packages.slack-bolt: 1.29.0 -> 1.30.0 ``                                               |
| [`7e5c1103`](https://github.com/NixOS/nixpkgs/commit/7e5c11033277f2c863921dec78d314f66c47a280) | `` python3Packages.streamlit: 1.61.1 -> 1.62.0 ``                                                |
| [`4470fca5`](https://github.com/NixOS/nixpkgs/commit/4470fca5764aa22822333bb996322f39a4959cf1) | `` nodejs_22: fix riscv64-linux build ``                                                         |
| [`dd22eddd`](https://github.com/NixOS/nixpkgs/commit/dd22eddde4963c18956c5a1825ec88f206b6d199) | `` pantheon.elementary-icon-theme: 8.2.0 -> 9.0.0 ``                                             |
| [`daa8a439`](https://github.com/NixOS/nixpkgs/commit/daa8a439e77678ca5b3868d7a6a89b1cebc312f6) | `` python3Packages.pypck: 0.9.13 -> 0.9.14 ``                                                    |
| [`e80a480b`](https://github.com/NixOS/nixpkgs/commit/e80a480bb2a47b6f769b994b2029281a71c3689a) | `` python3Packages.pyexploitdb: 0.3.40 -> 0.3.41 ``                                              |
| [`12d47601`](https://github.com/NixOS/nixpkgs/commit/12d476015a3cd50dd0cc76a37e3c6f9b95786fe8) | `` python3Packages.asteval: migrate to finalAttrs ``                                             |
| [`205a2703`](https://github.com/NixOS/nixpkgs/commit/205a2703af41aed516ce3d1da96cbb0b9157bdfc) | `` python3Packages.iamdata: 0.1.202608221 -> 0.1.202608231 ``                                    |
| [`cb92c61e`](https://github.com/NixOS/nixpkgs/commit/cb92c61e9496d10325d2b4ebb210f7fcafb72815) | `` terraform-providers.sap_btp: 1.25.0 -> 1.26.0 ``                                              |
| [`b1b2177d`](https://github.com/NixOS/nixpkgs/commit/b1b2177d8a7764525b93b11e83087a1b6d5aaa4a) | `` tmux: enable strictDeps, __structuredAttrs ``                                                 |
| [`d2936c1f`](https://github.com/NixOS/nixpkgs/commit/d2936c1f3e610aa606d6348a70280b2926d6a962) | `` leo-editor: 6.8.8 -> 6.8.10 ``                                                                |
| [`f01603b2`](https://github.com/NixOS/nixpkgs/commit/f01603b2eb5f055da5710d9faec762a9607f20c1) | `` grpc-health-probe: 0.4.55 -> 0.4.56 ``                                                        |
| [`c831451b`](https://github.com/NixOS/nixpkgs/commit/c831451b87ed4adc542ec64edd21aec5e8e0a41c) | `` idescriptor: 0.6.1 -> 0.6.2 ``                                                                |
| [`80905784`](https://github.com/NixOS/nixpkgs/commit/809057845c0a1f6485722264a100653c862de715) | `` vimPlugins.mesone-nvim: init at 2026-05-05 ``                                                 |
| [`3411a16a`](https://github.com/NixOS/nixpkgs/commit/3411a16a3e3aa90a904fa39bd24642b2afe66888) | `` nixosTests.hostname: migrate to runTest ``                                                    |
| [`09f6e223`](https://github.com/NixOS/nixpkgs/commit/09f6e2235cbbb153619386fba1f832650fd56534) | `` nixosTests.gitea: migrate to runTest ``                                                       |
| [`9311162a`](https://github.com/NixOS/nixpkgs/commit/9311162a03ac14375aa3d3c63ba50fb1feba7601) | `` jsonschema-cli: 0.49.9 -> 0.50.1 ``                                                           |
| [`56d4d710`](https://github.com/NixOS/nixpkgs/commit/56d4d710bd0bc7bcf953f6616bdc3e48c21ec549) | `` tmux: fix darwin build ``                                                                     |
| [`dce641a1`](https://github.com/NixOS/nixpkgs/commit/dce641a138017a78157615743ed7ef70c2dc576c) | `` tarsnap: modernize ``                                                                         |
| [`b18f1a38`](https://github.com/NixOS/nixpkgs/commit/b18f1a38680d019d27bb484301c2bcb1dd58e73b) | `` gx-go: fix version; enable structuredAttrs, version check ``                                  |
| [`07b0c35d`](https://github.com/NixOS/nixpkgs/commit/07b0c35dcb4cf148bb46c584bc5ad004bb1874aa) | `` spacetimedb: 2.8.1 -> 2.8.3 ``                                                                |
| [`fc4eb293`](https://github.com/NixOS/nixpkgs/commit/fc4eb293fa39693c419f8a301db905a5a1ae68f3) | `` pfcpsim: 1.4.4 -> 1.5.0 ``                                                                    |
| [`064d839c`](https://github.com/NixOS/nixpkgs/commit/064d839c4df96520ebf956ac7dbfa748c4e25b2a) | `` gst_all_1.icamerasrc-ipu6: fix version, use finalAttrs ``                                     |
| [`3d44c54d`](https://github.com/NixOS/nixpkgs/commit/3d44c54d89ca0c583d8cc21856ad18037b85e29c) | `` numkong: 7.8.0 -> 7.8.1 ``                                                                    |
| [`873957f0`](https://github.com/NixOS/nixpkgs/commit/873957f0d4260c1ab81d1a3f2774e28926ce56c7) | `` gsmlib: fix version, license; modernize ``                                                    |
| [`1691f387`](https://github.com/NixOS/nixpkgs/commit/1691f387ae10021cadd901a4125374f160d4aa74) | `` grpc-health-check: drop ``                                                                    |
| [`6ad2890b`](https://github.com/NixOS/nixpkgs/commit/6ad2890bf6c27aee1531691fe560662153b1cf8d) | `` home-assistant-custom-lovelace-modules.material-you-utilities: 2.1.24 -> 2.1.25 ``            |
| [`11019acd`](https://github.com/NixOS/nixpkgs/commit/11019acd952fbedcb5e7e7c73e9459b10fdca940) | `` home-assistant-themes.material-you-theme: 5.0.14 -> 5.0.15 ``                                 |
| [`5c3c6f81`](https://github.com/NixOS/nixpkgs/commit/5c3c6f819470741e477f63282dcd6c14bebedb5b) | `` goofys: fix version, vendorHash; modernize ``                                                 |
| [`13760c02`](https://github.com/NixOS/nixpkgs/commit/13760c02bf2f5402e3f25b790841137580336916) | `` files-cli: 2.15.442 -> 2.15.448 ``                                                            |
| [`5e064d05`](https://github.com/NixOS/nixpkgs/commit/5e064d0518ad532443bfbe3fd0cf11158fe6c30f) | `` antigravity-cli: 1.1.13 -> 1.1.19 ``                                                          |
| [`cdc44141`](https://github.com/NixOS/nixpkgs/commit/cdc4414183edc75690e911d7c53e83e452f8f892) | `` golint: fix version, enable structuredAttrs, use hash ``                                      |
| [`c96e6a4b`](https://github.com/NixOS/nixpkgs/commit/c96e6a4b37ceb1f05ab14c49808c184b485f4a9e) | `` go-sct: fix version, enable structuredAttrs ``                                                |
| [`eef928cd`](https://github.com/NixOS/nixpkgs/commit/eef928cd8012922a92234729882466fce5b0ca7c) | `` continuwuity: 26.7.3 -> 26.8.1 ``                                                             |
| [`05ae2769`](https://github.com/NixOS/nixpkgs/commit/05ae2769f58e1e202b4c0c2d9341f1fbb81cfafc) | `` go-outline: fix version; use structuredAttrs, hash ``                                         |
| [`aa8da3cf`](https://github.com/NixOS/nixpkgs/commit/aa8da3cf32294b7d9a1f2f45a70c5b976d389858) | `` subfinder: 2.15.0 -> 2.16.0 ``                                                                |
| [`55c95258`](https://github.com/NixOS/nixpkgs/commit/55c95258992803717b9503ec8ae5eadebeb22793) | `` cdncheck: 1.2.49 -> 1.2.50 ``                                                                 |
| [`c396b05f`](https://github.com/NixOS/nixpkgs/commit/c396b05f9ce11e4e1645d28de04b0cf9506c04db) | `` go-check: fix version, vendorHash; use structuredAttrs ``                                     |
| [`3130ffcb`](https://github.com/NixOS/nixpkgs/commit/3130ffcbaffe12783c4d918322e1f89805cb1754) | `` fuse-emulator: 1.9.0 -> 1.9.1 ``                                                              |
| [`8e6002f3`](https://github.com/NixOS/nixpkgs/commit/8e6002f30dfdb5af483ba420df7db1fd73212dae) | `` jacoco: 0.8.14 -> 0.8.15 ``                                                                   |
| [`ef553fa8`](https://github.com/NixOS/nixpkgs/commit/ef553fa8b55744cff06f09f121b7727ab073b94a) | `` go-bindata-assetfs: fix version, use structuredAttrs ``                                       |
| [`f966dba6`](https://github.com/NixOS/nixpkgs/commit/f966dba6f48603ef7aee56b3ab6d2498fa0cec68) | `` go-autoconfig: fix version; use hash, structuredAttrs ``                                      |
| [`a01d16a8`](https://github.com/NixOS/nixpkgs/commit/a01d16a8f97f492ed3fc60534de72b93b2909ead) | `` libosinfo: Use new project upstream URL ``                                                    |
| [`e9176a5d`](https://github.com/NixOS/nixpkgs/commit/e9176a5d6cfc35427ab198083cbf44df61e816e5) | `` osinfo-db-tools: Use new project upstream URL ``                                              |
| [`75bf61c7`](https://github.com/NixOS/nixpkgs/commit/75bf61c7c8634804ca9aae70102bb83214b305a8) | `` go-arch-lint: use go 1.27 ``                                                                  |
| [`a33ea98d`](https://github.com/NixOS/nixpkgs/commit/a33ea98d107100fcd4b49e5046f86f3b4d4958b5) | `` go-arch-lint: 1.17.0 -> 1.18.0 ``                                                             |
| [`0ff30df4`](https://github.com/NixOS/nixpkgs/commit/0ff30df420934a2621fe56bbcf860d16f87cb37d) | `` glow-lang: fix version ``                                                                     |
| [`465d3cd3`](https://github.com/NixOS/nixpkgs/commit/465d3cd394f47217b605149d0a7cf4997c7a7050) | `` fadein: init at 5.0.13 ``                                                                     |
| [`3c20022a`](https://github.com/NixOS/nixpkgs/commit/3c20022a66f801631f2b6db4e9ad3c297909d917) | `` cliamp: build with same ldflags as project makefile ``                                        |
| [`f0b486a6`](https://github.com/NixOS/nixpkgs/commit/f0b486a665e91564b550fddd4f5f476649aa81c7) | `` diffoscope: 328 -> 329 ``                                                                     |
| [`0e5835b9`](https://github.com/NixOS/nixpkgs/commit/0e5835b9ffbae343f32328718d01614b11f939ef) | `` fetchmtn: drop ``                                                                             |
| [`61e9fc2a`](https://github.com/NixOS/nixpkgs/commit/61e9fc2a59b97eb00fbce69a84ca88323dca82bf) | `` searxng: 0-unstable-2026-08-13 -> 0-unstable-2026-08-22 ``                                    |
| [`f519451f`](https://github.com/NixOS/nixpkgs/commit/f519451f1427adb34e8ca5eec982ff967ae51504) | `` mcp-server-time: 2026.7.10 -> 2026.8.18 ``                                                    |
| [`0300d50a`](https://github.com/NixOS/nixpkgs/commit/0300d50adb93bda93a5cf3e920df677fd879e3f0) | `` nixos/chromadb: fix double dot in option description ``                                       |
| [`5cf4337a`](https://github.com/NixOS/nixpkgs/commit/5cf4337a8c8249d585ecd1c2930f75e6d445b8cc) | `` mcp-server-git: 2026.7.10 -> 2026.8.18 ``                                                     |
| [`cd586e21`](https://github.com/NixOS/nixpkgs/commit/cd586e219d37a10ab62f3526374dd51db16697a8) | `` pkgs.formats: fix importing toPretty from lib.generators ``                                   |
| [`f51227e9`](https://github.com/NixOS/nixpkgs/commit/f51227e9964e2ba4a162d88695d80917b782e4ff) | `` atopile: orphan ``                                                                            |
| [`91ecf827`](https://github.com/NixOS/nixpkgs/commit/91ecf827dfa34b173e72f9e19ca4bb20d178bd41) | `` emacsPackages.ghostel: 0.50.0 -> 0.51.0 ``                                                    |
| [`d4969380`](https://github.com/NixOS/nixpkgs/commit/d4969380d2b4f30c50d9e9b5662576ace6c95a71) | `` home-assistant-custom-components.econet300: init at 1.3.0 ``                                  |
| [`b7346b2d`](https://github.com/NixOS/nixpkgs/commit/b7346b2df032a96f242fd7079dcb32725b40c892) | `` hifiscan: drop ``                                                                             |
| [`168103c9`](https://github.com/NixOS/nixpkgs/commit/168103c93cf06ca18ba08846708cb27a4ddd1d0d) | `` python3Packages.intake: cleanup ``                                                            |
| [`4358fbb7`](https://github.com/NixOS/nixpkgs/commit/4358fbb71a5ea235462f0cef29322a7a417a526a) | `` cargo-binstall: 1.21.1 -> 1.22.0 ``                                                           |
| [`14eb18c3`](https://github.com/NixOS/nixpkgs/commit/14eb18c3176fd8435cb15114bcadf951cd75ccba) | `` python3Packages.hvplot: cleanup ``                                                            |
| [`f9873e54`](https://github.com/NixOS/nixpkgs/commit/f9873e54379c2c25953c62f233ec36f3328803a8) | `` python3Packages.holoviews: 1.22.1 -> 1.23.1 ``                                                |
| [`66eedaf1`](https://github.com/NixOS/nixpkgs/commit/66eedaf1bf1de0e6c56a84a3cc5ed6276f8ebc12) | `` cherrytree: 1.7.1 -> 1.7.2 ``                                                                 |
| [`c4b2e8b5`](https://github.com/NixOS/nixpkgs/commit/c4b2e8b5c4abd35ffa26607f4763fdaef5e166f1) | `` gogcli: 0.36.0 -> 0.37.0 ``                                                                   |
| [`da9294b2`](https://github.com/NixOS/nixpkgs/commit/da9294b26c135a3314c953f01076cb3ef2acbaad) | `` python3Packages.ufonormalizer: modernize ``                                                   |
| [`eb2f1731`](https://github.com/NixOS/nixpkgs/commit/eb2f17318c9a7deeba43ee6a3a97a4bab5880339) | `` emacsPackages.info-variable-pitch: init at 0-unstable-2022-06-18 ``                           |
| [`c7729929`](https://github.com/NixOS/nixpkgs/commit/c7729929244bd11255f406bef78b90fa79cf677f) | `` brave, brave-origin: 1.93.136 -> 1.93.138 ``                                                  |
| [`c1d3bb86`](https://github.com/NixOS/nixpkgs/commit/c1d3bb8663c63929747c44193928f7436bfea942) | `` tea: 0.14.0 -> 0.15.1 ``                                                                      |
| [`43b23646`](https://github.com/NixOS/nixpkgs/commit/43b2364676684864a3d11ca7e7f3700685cdcc1e) | `` python3Packages.disposable-email-domains: 0.0.237 -> 0.0.242 ``                               |
| [`f343b7ba`](https://github.com/NixOS/nixpkgs/commit/f343b7bafca229e7d1a4dfa813978b29ebde8f1b) | `` mimir: 3.1.4 -> 3.2.0 ``                                                                      |
| [`6e153223`](https://github.com/NixOS/nixpkgs/commit/6e15322374cbba56ec5bd3e51ebc21ed533b17ca) | `` lookout: init at 0.3.11 ``                                                                    |
| [`32958684`](https://github.com/NixOS/nixpkgs/commit/329586840f3c48faabec901bc2ce3cea60d75144) | `` pyhanko-cli: move `pyyaml` dependency from pyhanko to pyhanko-cli ``                          |
| [`1ab96115`](https://github.com/NixOS/nixpkgs/commit/1ab96115dd093de2b862415b1bfda4867c5fa92b) | `` python3Packages.pyhanko: 0.35.2 -> 0.36.2 ``                                                  |
| [`3e145147`](https://github.com/NixOS/nixpkgs/commit/3e145147b5ce4b644a4f14c2e5485aa84686613c) | `` python3Packages.signxml: 4.5.1 -> 5.1.0 ``                                                    |
| [`662085de`](https://github.com/NixOS/nixpkgs/commit/662085ded26bcc2832ff2380c9f145b3ac5cc635) | `` python3Packages.python-pskc: 1.4 -> 1.4-unstable-2026-07-18 ``                                |
| [`8d685bc0`](https://github.com/NixOS/nixpkgs/commit/8d685bc03ea47ab5f47b1a70e6703e30b973ea83) | `` telemt: 3.4.25 -> 3.5.0 ``                                                                    |
| [`52fefad0`](https://github.com/NixOS/nixpkgs/commit/52fefad0424f51156ebdefe32706aad964096727) | `` sarasa-gothic: 1.0.40 -> 1.0.41 ``                                                            |
| [`f4aa13cb`](https://github.com/NixOS/nixpkgs/commit/f4aa13cbdfb430bdcff1eb3ca0a9a8c646ef7a58) | `` python3Packages.asteval: 1.0.9 -> 1.0.10 ``                                                   |
| [`655e5659`](https://github.com/NixOS/nixpkgs/commit/655e56593d780ae07f555773b11b951d13499a66) | `` bitwarden-desktop: 2026.7.0 -> 2026.8.0 ``                                                    |
| [`8da980fe`](https://github.com/NixOS/nixpkgs/commit/8da980fe350cbbb032106ec15f98609852876e2d) | `` kdePackages.kio-snapshot: init at 1.0.0 ``                                                    |
| [`3a005dde`](https://github.com/NixOS/nixpkgs/commit/3a005dde29414ea42f0678c63867b3440106e00c) | `` terraform-backend: 0.2.2 -> 0.2.3 ``                                                          |
| [`31af3aec`](https://github.com/NixOS/nixpkgs/commit/31af3aec65db4605b7aaf6731b4b419385bbc2d1) | `` hk: 1.55.0 -> 1.56.0 ``                                                                       |
| [`38f95b37`](https://github.com/NixOS/nixpkgs/commit/38f95b37816a896496a7fceab85a48d5b7081f68) | `` appium-inspector: update to electron v43 ``                                                   |
| [`0f3ba3b5`](https://github.com/NixOS/nixpkgs/commit/0f3ba3b5cb561bd8a76102b8f2aa55a2a6ebcdea) | `` maintainers: add i-love-lean ``                                                               |
| [`0ad22e1a`](https://github.com/NixOS/nixpkgs/commit/0ad22e1aaf636ee14582801b69baea0a309844ec) | `` vulkan-caps-viewer: 4.12 -> 4.13 ``                                                           |
| [`21f786eb`](https://github.com/NixOS/nixpkgs/commit/21f786eb46554a99fa63c56638d29ee1cb412981) | `` wpprobe: 0.12.5 -> 0.12.7 ``                                                                  |
| [`c668e715`](https://github.com/NixOS/nixpkgs/commit/c668e7150467100c888c63ba5699f8c20897ecff) | `` terraform-providers.scaleway_scaleway: 2.80.0 -> 2.81.0 ``                                    |
| [`e034dacb`](https://github.com/NixOS/nixpkgs/commit/e034dacbf0fa3652ebd1e011904af22dc7a47bf2) | `` ssh-vault: 1.3.2 -> 1.3.4 ``                                                                  |
| [`20b3290a`](https://github.com/NixOS/nixpkgs/commit/20b3290a22ebb45239101b8be30e275ce464e67e) | `` python3Packages.rns: 1.4.2 -> 1.5.0 ``                                                        |
| [`6c7d52b8`](https://github.com/NixOS/nixpkgs/commit/6c7d52b81b6378b6da8f19c4f8be7d32d5c4a30d) | `` lazyspotify: mark as broken ``                                                                |
| [`adf140a6`](https://github.com/NixOS/nixpkgs/commit/adf140a6377d4f8fea4fc7bc331901edb7437794) | `` zerofs: 2.2.3 -> 2.3.0 ``                                                                     |
| [`9c77b79f`](https://github.com/NixOS/nixpkgs/commit/9c77b79f30e67f07c54d4a0d1898d9f2a3012ced) | `` koboldcpp: 1.110 -> 1.119 ``                                                                  |
| [`8ae8eb81`](https://github.com/NixOS/nixpkgs/commit/8ae8eb81d4525080c6a2a7690439abd44587eae3) | `` rio: 0.5.24 -> 0.5.25 ``                                                                      |
| [`e231e15b`](https://github.com/NixOS/nixpkgs/commit/e231e15be2bfc3ac6954d8526624c2802f52a9ea) | `` cudatext: 1.236.0.3 -> 1.236.0.4 ``                                                           |
| [`ddabbe15`](https://github.com/NixOS/nixpkgs/commit/ddabbe15e75ca4d46ea10bf3a10d7c727edca0ca) | `` python3Packages.adsbcot: init at 9.0.1 ``                                                     |
| [`c1e06b85`](https://github.com/NixOS/nixpkgs/commit/c1e06b85d56d433c392cdea3fb4efae9eeaa1199) | `` python3Packages.aircot: init at 4.0.2 ``                                                      |
| [`ee67f96d`](https://github.com/NixOS/nixpkgs/commit/ee67f96dfb14b4132b8f3e6a639014435389cc52) | `` python3Packages.aiscot: init at 7.1.3 ``                                                      |
| [`37925c30`](https://github.com/NixOS/nixpkgs/commit/37925c30d66b88d56644f2732ce7959ddb4f7b33) | `` python3Packages.pytak: init at 7.3.10 ``                                                      |
| [`ff545c48`](https://github.com/NixOS/nixpkgs/commit/ff545c4876a446c795dd0c6fdba605cc3f3b25b4) | `` buildbox: 1.4.17 -> 1.4.18 ``                                                                 |
| [`07b7b3ac`](https://github.com/NixOS/nixpkgs/commit/07b7b3ac22044b279e5dc507e5b6a0b9c36dd3d4) | `` xmrig-proxy: unmaintain ``                                                                    |
| [`89c2c3f7`](https://github.com/NixOS/nixpkgs/commit/89c2c3f7a16fe2bbdff99f952a4e03a14c2efd3a) | `` shader-slang: 2026.14.1 -> 2026.16 ``                                                         |
| [`6a1df0a9`](https://github.com/NixOS/nixpkgs/commit/6a1df0a9a09a810e1f057d5049f5b20099c7d0ad) | `` protobuf_36: init at 36.0 ``                                                                  |
| [`94eb3559`](https://github.com/NixOS/nixpkgs/commit/94eb3559d92ab99573badc48814e6338cfeb9c27) | `` rectangle: 0.98 -> 0.99 ``                                                                    |
| [`ec02c3f0`](https://github.com/NixOS/nixpkgs/commit/ec02c3f03f3514f4de41743b743928aa6e1a6d20) | `` ligolo-ng: 0.8.3 -> 0.9.1 ``                                                                  |
| [`ff328581`](https://github.com/NixOS/nixpkgs/commit/ff328581a322296a8268525671dc4fc362778d48) | `` chsrc: 0.2.6 -> 0.2.7 ``                                                                      |
| [`f1935fe4`](https://github.com/NixOS/nixpkgs/commit/f1935fe4c97588012a41aa2cf2cb9d466999dcd3) | `` nixos/udp514-journal: add module ``                                                           |
| [`d347bbc0`](https://github.com/NixOS/nixpkgs/commit/d347bbc0d24b6d12583edd189413e1641bf54d05) | `` udp514-journal: init at 0.3.0 ``                                                              |
| [`a9d7c5a8`](https://github.com/NixOS/nixpkgs/commit/a9d7c5a803c3d29f411851593b7e7b58d644da7d) | `` python3Packages.cramjam: enable __structuredAttrs ``                                          |
| [`f7309745`](https://github.com/NixOS/nixpkgs/commit/f7309745a6a627d13072fe3e7ac50ae34f3d3ba4) | `` gl3w: 0-unstable-2025-11-07 -> 0-unstable-2026-08-17 ``                                       |
| [`5c4eaae3`](https://github.com/NixOS/nixpkgs/commit/5c4eaae36fedd82fe63ad90bdfc1c693f3531a66) | `` python3Packages.cramjam: fix hash ``                                                          |
| [`8c27e144`](https://github.com/NixOS/nixpkgs/commit/8c27e1444466e6496bffa08e95005c9ebd4d6524) | `` kitex: 0.16.2 -> 0.16.3 ``                                                                    |
| [`51343ae3`](https://github.com/NixOS/nixpkgs/commit/51343ae3245ddfb13a1584496718d237bb2ab1d8) | `` qownnotes: 26.8.2 -> 26.8.7 ``                                                                |
| [`a5f2c005`](https://github.com/NixOS/nixpkgs/commit/a5f2c00558eba570d6a3f320db6f08078a871ced) | `` ibtool: 1.2.0 -> 1.2.1 ``                                                                     |
| [`cfd1ab7e`](https://github.com/NixOS/nixpkgs/commit/cfd1ab7e68ca15709b484ffcabf0f714b79a6cc4) | `` bisq2: 2.1.11 -> 2.1.12 ``                                                                    |
| [`645d086d`](https://github.com/NixOS/nixpkgs/commit/645d086d79324e822feec774bfc4409d6a40db9a) | `` hjson-go: 4.6.0 -> 4.7.0 ``                                                                   |
| [`f0c16843`](https://github.com/NixOS/nixpkgs/commit/f0c168433fba9201c5e2d635f9bb8ea18607e2a4) | `` cargo-lambda: 1.9.1 -> 1.9.2 ``                                                               |
| [`afbf4a3c`](https://github.com/NixOS/nixpkgs/commit/afbf4a3cee66206f9a75e840c5f122245f65677a) | `` nixos/tests/rosec: init ``                                                                    |
| [`a4d75623`](https://github.com/NixOS/nixpkgs/commit/a4d7562390d0b018e464ac8c8cb1b4169667c62e) | `` nixos/pam: add rosec ``                                                                       |
| [`451af617`](https://github.com/NixOS/nixpkgs/commit/451af617f3119b4136c3b32d326b3dd198f8076e) | `` nixos/rosec: init module ``                                                                   |
| [`913cc1a6`](https://github.com/NixOS/nixpkgs/commit/913cc1a60398f11289f1b2a19f2854c878e57cab) | `` top-level/all-packages.nix: add rosecFull ``                                                  |
| [`08392c47`](https://github.com/NixOS/nixpkgs/commit/08392c4798a3a1712a0b55ec53d46e3c1743bd4d) | `` rosec-gnome-keyring: init at 0.0.28 ``                                                        |
| [`ad500a8f`](https://github.com/NixOS/nixpkgs/commit/ad500a8f37d1cc082e26de5163bf71b4049f0f4b) | `` rosec-bitwarden-sm: init at 0.0.28 ``                                                         |
| [`b13a2fd7`](https://github.com/NixOS/nixpkgs/commit/b13a2fd7bc886dfc13257e02c4b247bf54cbcf2f) | `` rosec-bitwarden-pm: init at 0.0.28 ``                                                         |
| [`c2ff24de`](https://github.com/NixOS/nixpkgs/commit/c2ff24dedf6149479854f6ab62b487460b4444ff) | `` rosec: init at 0.0.28 ``                                                                      |
| [`929a59a6`](https://github.com/NixOS/nixpkgs/commit/929a59a620edf38e6151a47df59d5544cc079eb5) | `` keymapper: 5.6.0 -> 5.7.0 ``                                                                  |
| [`4eecc007`](https://github.com/NixOS/nixpkgs/commit/4eecc007b5bf01f9c18c3d9267c19d98a1aa2002) | `` qsampler: 1.0.2 -> 1.0.3 ``                                                                   |
| [`8b8b6ddd`](https://github.com/NixOS/nixpkgs/commit/8b8b6ddd128f4c3df5195fbfd516bc548d07be25) | `` python3Packages.uproot: 5.7.5 -> 5.7.6 ``                                                     |
| [`13e7ac9c`](https://github.com/NixOS/nixpkgs/commit/13e7ac9c390982faa4fd7ca29b5045e2d298022b) | `` iortcw_sp: migrate to by-name ``                                                              |
| [`cc766dae`](https://github.com/NixOS/nixpkgs/commit/cc766dae0e6597aaaa4bbd2cf6a138395a5ec5f1) | `` iortcw_sp: add strictDeps and structuredAttrs ``                                              |
| [`19cda845`](https://github.com/NixOS/nixpkgs/commit/19cda8457497c487d570c8e442221739761f05b7) | `` netbird-combined: init at 0.77.1 ``                                                           |
| [`46868897`](https://github.com/NixOS/nixpkgs/commit/4686889793c5e270eb35c60a3d688f5d91efac96) | `` rapidraw: 1.6.1 -> 1.6.2 ``                                                                   |
| [`b26ea6c5`](https://github.com/NixOS/nixpkgs/commit/b26ea6c5abb6d03b9948e5b7cf807ded834db8c8) | `` hydralauncher: 4.1.1 -> 4.1.2 ``                                                              |
| [`b0e56b77`](https://github.com/NixOS/nixpkgs/commit/b0e56b774ef5aef75a50a94a3244a8241f5729e5) | `` vaultwarden: 1.37.1 -> 1.37.2 ``                                                              |
| [`80232f25`](https://github.com/NixOS/nixpkgs/commit/80232f258c0f9ff53d9cfbbe23e07041a1ae0fee) | `` python3Packages.jax-cuda12-plugin: refactor src logic ``                                      |
| [`d9286977`](https://github.com/NixOS/nixpkgs/commit/d92869776723f377e92c047a7984bf4d7eccb08b) | `` python3Packages.jax-cuda12-pjrt: refactor src logic ``                                        |
| [`456f1b07`](https://github.com/NixOS/nixpkgs/commit/456f1b07977b03a2d2a58894bb8d8aa6100e6b87) | `` tellico: 4.2.1 -> 4.2.2 ``                                                                    |
| [`b7d8eace`](https://github.com/NixOS/nixpkgs/commit/b7d8eace54b6f645e6dadd0c2b90aef5fa66a23e) | `` simpleBuildTool: 2.0.6 -> 2.0.7 ``                                                            |
| [`6cb1c4a7`](https://github.com/NixOS/nixpkgs/commit/6cb1c4a7210d339fa04f4d211eb6aa001722187d) | `` python3Packages.huaweicloudsdk: update script permission ``                                   |
| [`d7d07509`](https://github.com/NixOS/nixpkgs/commit/d7d075090e6665759466b7ad6d571e3d7747c9fc) | `` python3Packages.huaweicloudsdk*: 3.1.210 -> 3.1.211 ``                                        |
| [`86600253`](https://github.com/NixOS/nixpkgs/commit/8660025366ccb054b85829c832a53d42b0003ac2) | `` mcp-server-fetch: 2026.7.10 -> 2026.8.18 ``                                                   |
| [`1d39abb4`](https://github.com/NixOS/nixpkgs/commit/1d39abb4401ac0832a561afdc5df545bf207e544) | `` rerun: 0.36.1 -> 0.36.2 ``                                                                    |
| [`52e9a776`](https://github.com/NixOS/nixpkgs/commit/52e9a77672f23f906b75c5d5b4c0a8598a4b1cdb) | `` home-assistant-custom-components.midea_ac: drop emilylange as maintainer ``                   |
| [`d7610bb3`](https://github.com/NixOS/nixpkgs/commit/d7610bb34b5f2dd914c646020f4e0bd1bf638a60) | `` python3Packages.msmart-ng: drop emilylange as maintainer ``                                   |
| [`5442278d`](https://github.com/NixOS/nixpkgs/commit/5442278dbf053f8d7fd76b95d343064e71cd178d) | `` uptime-kuma: 2.5.0 -> 2.5.3 ``                                                                |
| [`22543a6d`](https://github.com/NixOS/nixpkgs/commit/22543a6da8b678ed2ca1c3a2a8976838da51647a) | `` prowler: add updateScript ``                                                                  |
| [`dc158add`](https://github.com/NixOS/nixpkgs/commit/dc158addc2e06858bd7ca20cb7d89432279ebb5e) | `` simplex-chat-desktop: 7.0.0 -> 7.0.1 ``                                                       |
| [`57133294`](https://github.com/NixOS/nixpkgs/commit/57133294070ad478cbde5f6c4ef8dc63261f92c1) | `` pkgsite: 0.3.0-unstable-2026-08-12 -> 0.4.0-unstable-2026-08-19 ``                            |
| [`2fd57bec`](https://github.com/NixOS/nixpkgs/commit/2fd57bec1fe170dd4447192dc842ebcb2215b522) | `` exim: update meta.changelog ``                                                                |
| [`58bf4b2a`](https://github.com/NixOS/nixpkgs/commit/58bf4b2ac70dd7b5f1bc1e83daac21f2b1e8a631) | `` home-assistant-custom-components.midea_ac: 2026.7.2 -> 2026.8.2 ``                            |
| [`28e4ceb5`](https://github.com/NixOS/nixpkgs/commit/28e4ceb5422e9ac0168df965fc23713d6b31a55b) | `` python3Packages.msmart-ng: 2026.7.0 -> 2026.8.0 ``                                            |
| [`133d262f`](https://github.com/NixOS/nixpkgs/commit/133d262f488c2ed272b0b77e0b3dca0ac2531e70) | `` shairport-sync-airplay2: 5.2.1 -> 5.2.2 ``                                                    |
| [`602266f7`](https://github.com/NixOS/nixpkgs/commit/602266f7a1f714016dd32fd39e993957b28045fe) | `` intel-llvm: 7.0.0 -> 7.0.1 ``                                                                 |
| [`b145ec11`](https://github.com/NixOS/nixpkgs/commit/b145ec113aa6f605dcdf487904330f40036975c2) | `` home-assistant.python3Packages.pytest-homeassistant-custom-component: 0.13.356 -> 0.13.357 `` |
| [`83bcce52`](https://github.com/NixOS/nixpkgs/commit/83bcce5265bb899cc0f4c2602ca2a248f2645528) | `` python3Packages.homeassistant-stubs: 2026.8.2 -> 2026.8.3 ``                                  |
| [`96bc2ad8`](https://github.com/NixOS/nixpkgs/commit/96bc2ad8089f762ca6f732195841d2b7b9f41d46) | `` phpstan: 2.2.8 -> 2.2.9 ``                                                                    |
| [`2cf3f231`](https://github.com/NixOS/nixpkgs/commit/2cf3f2312db211da8ffe8d1127f62693248c92a2) | `` Revert "python3Packages.nsapi: 3.1.3 -> 3.2.1" ``                                             |
| [`531f0dc2`](https://github.com/NixOS/nixpkgs/commit/531f0dc2429d932c963a5d3c1d207363a4f96fe7) | `` ioq3-scion: Fix invalid unstable version scheme ``                                            |
| [`4b5416a4`](https://github.com/NixOS/nixpkgs/commit/4b5416a4727ea94401ef555666da750c3f5b52f2) | `` syswatch: 0.9.0 -> 0.10.0 ``                                                                  |
| [`364a34ef`](https://github.com/NixOS/nixpkgs/commit/364a34efde75a2d37456caa764740948b6627790) | `` autobrr: 1.83.0 -> 1.84.0 ``                                                                  |
| [`5f85a77f`](https://github.com/NixOS/nixpkgs/commit/5f85a77f6b4709f5c090c67f084a8b67c482ce2a) | `` eslint: 10.8.1 -> 10.9.0 ``                                                                   |
| [`0a904c95`](https://github.com/NixOS/nixpkgs/commit/0a904c95c15f301af8f7493c50c927a4e8209299) | `` home-assistant-custom-components.tibber_local: 2026.7.2 -> 2026.8.0 ``                        |
| [`f8bc03ef`](https://github.com/NixOS/nixpkgs/commit/f8bc03ef3571176fcfc81230374b14a5d105f4ad) | `` terraform-providers.hashicorp_http: 3.6.0 -> 3.6.1 ``                                         |
| [`71ad6db3`](https://github.com/NixOS/nixpkgs/commit/71ad6db3548e7c3d3f4bd671cf0a423856500e90) | `` python3Packages.skia-pathops: drop x86_64-darwin patches ``                                   |
| [`f5edd502`](https://github.com/NixOS/nixpkgs/commit/f5edd502a2577ea29a0d47bd4a6537fe3bbd704f) | `` python3Packages.skia-pathops: fix loongarch64-linux build ``                                  |
| [`b41398f9`](https://github.com/NixOS/nixpkgs/commit/b41398f9f5e5dc90c5caefd0f34dee01ab070e6c) | `` filebrowser-quantum: add updateScript ``                                                      |
| [`d7aa6703`](https://github.com/NixOS/nixpkgs/commit/d7aa670394c23ce4cf4facb76f2541ef8c6a69a6) | `` python3Packages.huaweicloudsdkcore: 3.1.210 -> 3.1.211 ``                                     |
| [`704d9951`](https://github.com/NixOS/nixpkgs/commit/704d99515e28764a2a28c5b3bcbe86139ef8adcc) | `` json-tui: 1.4.1 → 1.4.2 ``                                                                    |
| [`59402c71`](https://github.com/NixOS/nixpkgs/commit/59402c710d7b45795e1d08e73e7481f892a00ff6) | `` dataform: 3.0.64 -> 3.0.65 ``                                                                 |
| [`17e4e4cc`](https://github.com/NixOS/nixpkgs/commit/17e4e4cc8412425afdff6455083051f56cb4e744) | `` ftxui: 6.1.9 → 7.0.3 ``                                                                       |
| [`1607f70e`](https://github.com/NixOS/nixpkgs/commit/1607f70e63de5cf30cf4deb617d0e8860f4d505d) | `` greenmask: 0.2.22 -> 0.2.23 ``                                                                |
| [`244e0ab6`](https://github.com/NixOS/nixpkgs/commit/244e0ab6a7b575ad63014da35b9f4157da8f6db1) | `` linuxPackages.apfs: 0.3.20 -> 0.3.21-unstable-2025-08-15 ``                                   |
| [`1db6c5d7`](https://github.com/NixOS/nixpkgs/commit/1db6c5d7007a044aba8dcc7eeb2809c06fe1fb64) | `` python3Packages.iamdata: 0.1.202608211 -> 0.1.202608221 ``                                    |
| [`4ac79832`](https://github.com/NixOS/nixpkgs/commit/4ac79832706c1828d27930e4ac275babb4b5f547) | `` nixosTests.fail2ban: improve tests ``                                                         |
| [`a7750865`](https://github.com/NixOS/nixpkgs/commit/a7750865cbbfb105d548b28bc1eb36f064918b94) | `` nixos/fail2ban: use systemd socket activation ``                                              |
| [`c92580bf`](https://github.com/NixOS/nixpkgs/commit/c92580bfac773deee3b0cea7a89862d7231c49f9) | `` fail2ban: include fixes for systemd socket activation ``                                      |
| [`2a76f3de`](https://github.com/NixOS/nixpkgs/commit/2a76f3de382b8436b88f8072449c314d1071f1d6) | `` mongodb-atlas-cli: 1.58.0 -> 1.58.1 ``                                                        |
| [`0007fe37`](https://github.com/NixOS/nixpkgs/commit/0007fe370ab8a8828d7c7944f36a6c5de786d9d9) | `` cliamp: 1.63.1 -> 1.63.2 ``                                                                   |
| [`d1821e5f`](https://github.com/NixOS/nixpkgs/commit/d1821e5fbf57b3fdead593709317174af208dff4) | `` python3Packages.wagtail-localize: 1.13.1 -> 1.14.5 ``                                         |
| [`67e9fe04`](https://github.com/NixOS/nixpkgs/commit/67e9fe044aed0269ea9940f5268b5881829c50dd) | `` froide: modernize package ``                                                                  |
| [`6f9a44f8`](https://github.com/NixOS/nixpkgs/commit/6f9a44f80585c987559827ca5118556dbc319515) | `` froide: 0-unstable-2025-09-10 -> 0-unstable-2026-08-19 ``                                     |
| [`54d7c121`](https://github.com/NixOS/nixpkgs/commit/54d7c1218f343595e0d83821e2d04ecdebbcc290) | `` python3Packages.django-extended-makemessages: init at 1.9.0 ``                                |
| [`f037f91a`](https://github.com/NixOS/nixpkgs/commit/f037f91adf7cca22b5caa168c7672963ae8eb3b4) | `` python3Packages.wagtail: pin django-treebeard to a known working version ``                   |
| [`c6bdf7d3`](https://github.com/NixOS/nixpkgs/commit/c6bdf7d36d9b5e2296a35c190a3ba9d7b5172d9e) | `` python3Packages.petl: 1.7.23 -> 1.7.24 ``                                                     |
| [`5ea6e97a`](https://github.com/NixOS/nixpkgs/commit/5ea6e97a13119858cf90c187be849b1d2bb1cb47) | `` kustomize-lint: modernize ``                                                                  |
| [`ded44c59`](https://github.com/NixOS/nixpkgs/commit/ded44c594025ebb0508c64057a849b0b9791fd20) | `` python3Packages.rembg: 2.0.80 -> 2.0.81 ``                                                    |
| [`f35ef591`](https://github.com/NixOS/nixpkgs/commit/f35ef591108ad792a128108407054b52396ed8e7) | `` serverpod_cli: 3.4.11 -> 3.4.12 ``                                                            |
| [`880772cf`](https://github.com/NixOS/nixpkgs/commit/880772cf2d5bf77bc634f2b42cc5b4e0dd984b8d) | `` home-assistant-custom-components.gtfs-realtime: 0.4.8 -> 0.4.9 ``                             |
| [`059ae5cd`](https://github.com/NixOS/nixpkgs/commit/059ae5cdba9e3aa5afd2089cc65a34e4ce8abae3) | `` treewide: remove misusses of env and $TMPDIR ``                                               |
| [`fe1adbe6`](https://github.com/NixOS/nixpkgs/commit/fe1adbe6cf953f1dc38efead4f0e79ac77bac53c) | `` zennotes-desktop: 2.31.0 -> 2.35.0, electron 41 -> 42 ``                                      |
| [`38d1bfb6`](https://github.com/NixOS/nixpkgs/commit/38d1bfb669bcbaaa5b58460cef34eab0756b40aa) | `` _1password-cli: 2.38.1 -> 2.39.0 ``                                                           |
| [`bfb42b90`](https://github.com/NixOS/nixpkgs/commit/bfb42b90b86aa629c303f7ae3beaf3c70ccd251c) | `` zfs: replace systemd dependency with systemdMinimal ``                                        |
| [`899b0c4e`](https://github.com/NixOS/nixpkgs/commit/899b0c4e1933a006236e89bff80b22d5d51b731c) | `` sticky: 1.31 -> 1.32 ``                                                                       |
| [`6b308b76`](https://github.com/NixOS/nixpkgs/commit/6b308b76f941a166592a90ca4a896ee992a8630f) | `` lenovo-legion: 0.0.21-unstable-2026-08-07 -> 0.0.22-unstable-2026-08-21 ``                    |
| [`e2fdd568`](https://github.com/NixOS/nixpkgs/commit/e2fdd56864951db0cdecf79f1e68d17fb6a82d54) | `` gogcli: fix build metadata linker paths ``                                                    |
| [`f56d868f`](https://github.com/NixOS/nixpkgs/commit/f56d868f6e64e132caf0a8ccf1373941b598e579) | `` gogcli: 0.29.0 -> 0.36.0 ``                                                                   |
| [`ef3c92ae`](https://github.com/NixOS/nixpkgs/commit/ef3c92aebb96537ce5789117acc4af5de606a769) | `` dolt: 2.3.0 -> 2.3.1 ``                                                                       |
| [`91ba0360`](https://github.com/NixOS/nixpkgs/commit/91ba0360bd0330df1723e1405dcf0f3bbbf6428d) | `` home-assistant-custom-components.local_openai: 1.10.0 -> 1.11.1 ``                            |
| [`1a546e89`](https://github.com/NixOS/nixpkgs/commit/1a546e89aee43ab7307027ac071a7e1543daf277) | `` oxlint: 1.78.0 -> 1.79.0 ``                                                                   |
| [`f134e916`](https://github.com/NixOS/nixpkgs/commit/f134e916193d4bb784b2d08c9db6964ff3a9a15c) | `` stasis: 1.4.1 -> 1.5.1 ``                                                                     |
| [`74de4423`](https://github.com/NixOS/nixpkgs/commit/74de442343440eb60decae19df8a4708884fae99) | `` python3Packages.boto3-stubs: 1.43.76 -> 1.43.78 ``                                            |
| [`d2f6d0fc`](https://github.com/NixOS/nixpkgs/commit/d2f6d0fc1fdd4ac77db9b8d0930997e38d14b09c) | `` python3Packages.mypy-boto3-wafv2: 1.43.63 -> 1.43.78 ``                                       |
| [`aed17f01`](https://github.com/NixOS/nixpkgs/commit/aed17f01bdfbe655795d90374ee2a2440cecc8cc) | `` python3Packages.mypy-boto3-kinesis: 1.43.0 -> 1.43.78 ``                                      |
| [`af937195`](https://github.com/NixOS/nixpkgs/commit/af937195518888cead4c139c26020837bb9fe28c) | `` python3Packages.mypy-boto3-devicefarm: 1.43.66 -> 1.43.78 ``                                  |
| [`41a6ab15`](https://github.com/NixOS/nixpkgs/commit/41a6ab158c99dbcdbc8f466dc1268a4c141024b0) | `` python3Packages.mypy-boto3-cloudwatch: 1.43.54 -> 1.43.78 ``                                  |
| [`5701aa9c`](https://github.com/NixOS/nixpkgs/commit/5701aa9c5314bdd2fe95d66da20cf9563030696f) | `` python3Packages.mypy-boto3-backup: 1.43.66 -> 1.43.78 ``                                      |
| [`886d8c4d`](https://github.com/NixOS/nixpkgs/commit/886d8c4dd3650baf99957df3f834715b65519605) | `` mergiraf: 0.18.0 -> 0.19.0 ``                                                                 |
| [`801eebd0`](https://github.com/NixOS/nixpkgs/commit/801eebd00c08e243334f09c41f62b903e919e9e0) | `` pg_checksums: 1.3 -> 1.4 ``                                                                   |
| [`4756b493`](https://github.com/NixOS/nixpkgs/commit/4756b4938b11d7e9a23bb445da45dafa0040eba2) | `` reaper: 7.78 -> 7.79 ``                                                                       |
| [`a0d038dd`](https://github.com/NixOS/nixpkgs/commit/a0d038dde21ddcdc8e5ecbd9040b46617b1a83e6) | `` python3Packages.ghapi: 1.0.15 -> 2.1.2 ``                                                     |
| [`33e2b47d`](https://github.com/NixOS/nixpkgs/commit/33e2b47d4818aaa6fbefa3509508dd15bca1a9c4) | `` python3Packages.fastspec: init at 0.2.3 ``                                                    |
| [`c4d45835`](https://github.com/NixOS/nixpkgs/commit/c4d4583574e71afe2bf4b8d8371a6c6370dd4ad8) | `` home-assistant: 2026.8.2 -> 2026.8.3 ``                                                       |
| [`a1acbfe9`](https://github.com/NixOS/nixpkgs/commit/a1acbfe93e705e85cff5a8307d96777e19154546) | `` python3Packages.volvocarsapi: 0.4.3 -> 0.4.4 ``                                               |
| [`ccf5fd37`](https://github.com/NixOS/nixpkgs/commit/ccf5fd374f275647d7520de43f5a8e3f54c78157) | `` python3Packages.reolink-aio: 0.21.8 -> 0.21.9 ``                                              |
| [`0dc79f90`](https://github.com/NixOS/nixpkgs/commit/0dc79f90fb6c765aa27768ff7f50dd29c29b4a80) | `` python3Packages.pyenphase: 3.2.2 -> 4.0.0 ``                                                  |
| [`77db2203`](https://github.com/NixOS/nixpkgs/commit/77db2203fc8ee547b500dfdd6181b08f6a47b2d3) | `` python3Packages.ical: 14.1.0 -> 14.1.1 ``                                                     |
| [`05845c76`](https://github.com/NixOS/nixpkgs/commit/05845c76ad9607089646dca78de9ab413b365bfd) | `` python3Packages.aiowebostv: 0.9.1 -> 0.9.2 ``                                                 |
| [`924f3f5f`](https://github.com/NixOS/nixpkgs/commit/924f3f5f2b8f89fd96464fb1c69250a19089555a) | `` python3Packages.fasttransport: init at 0.0.1 ``                                               |
| [`92ae1534`](https://github.com/NixOS/nixpkgs/commit/92ae1534824280564fd087b3dfa60c4147f3a063) | `` prometheus: 3.13.2 -> 3.14.0 ``                                                               |
| [`b747ec47`](https://github.com/NixOS/nixpkgs/commit/b747ec475f1fb23f612e3dbc2f988265d5dcb4b7) | `` python3Packages.apprise: 1.11.0 -> 1.13.0 ``                                                  |
| [`d03f154c`](https://github.com/NixOS/nixpkgs/commit/d03f154cf20a55b70ce86a9da7f09a7f47e96211) | `` python3Packages.types-aiobotocore-*: 3.8.0 -> 3.9.0 ``                                        |
| [`8f58ebae`](https://github.com/NixOS/nixpkgs/commit/8f58ebaec5c4c9eadbbbae275a4c8adcc818b525) | `` python3Packages.cyclopts: 4.23.0 -> 4.23.1 ``                                                 |
| [`14176b6b`](https://github.com/NixOS/nixpkgs/commit/14176b6b0f774c9b83e511ccf1841a72180a6a79) | `` python3Packages.intellifire4py: 4.5.1 -> 4.5.4 ``                                             |
| [`06feeac1`](https://github.com/NixOS/nixpkgs/commit/06feeac1b78391f06da4bdb8712c21bf894c45d9) | `` python3Packages.caido-sdk-client: 0.2.0 -> 0.3.1 ``                                           |
| [`b78e0e15`](https://github.com/NixOS/nixpkgs/commit/b78e0e15bca3c0e80dd668c5ba3eae11a451400d) | `` python3Packages.caido-schema-proxy: 0.57.1 -> 0.58.0 ``                                       |
| [`78708967`](https://github.com/NixOS/nixpkgs/commit/787089672e6e4f297e626c7802b8d6f212fed915) | `` zfs_2_4: 2.4.3 -> 2.4.4 ``                                                                    |
| [`c281f2d7`](https://github.com/NixOS/nixpkgs/commit/c281f2d7efe6900c7fdd7395fea839ace8d0cde7) | `` zfs_2_3: 2.3.8 -> 2.3.9 ``                                                                    |
| [`5945396f`](https://github.com/NixOS/nixpkgs/commit/5945396ff4c40046b95c2874e4b681a2ac7267f2) | `` nixos/tests: filter tests unavailable on the host ``                                          |
| [`abaaf7df`](https://github.com/NixOS/nixpkgs/commit/abaaf7dfe3369eaf5247db5012bf8bfe9e04f7ce) | `` nixos/tests: mark nspawn tests as Linux-only ``                                               |
| [`5d4a7a94`](https://github.com/NixOS/nixpkgs/commit/5d4a7a940d1b0d699020988afd1194202fedf3e6) | `` python3Packages.spacy-pkuseg: update description, sort ``                                     |
| [`acfe23f1`](https://github.com/NixOS/nixpkgs/commit/acfe23f1ac85b7ea84e4b19f4dd1ad4c72a39051) | `` adpathfinder: init at 1.2.0 ``                                                                |
| [`f56e6c3e`](https://github.com/NixOS/nixpkgs/commit/f56e6c3e3f628a909c951690fdcb89f3468430b5) | `` gopodder: 1.2.2 -> 1.2.3 ``                                                                   |
| [`b5e5284c`](https://github.com/NixOS/nixpkgs/commit/b5e5284cafb323081ff4af8573b0d027719661c0) | `` amd-libflame: 5.1 -> 5.3.2 ``                                                                 |
| [`e3bbbd53`](https://github.com/NixOS/nixpkgs/commit/e3bbbd53d71e08469f38a9bd035eadf8ae4550cf) | `` thunderbird-latest-bin-unwrapped: 153.0.3 -> 154.0 ``                                         |
| [`9df9ad01`](https://github.com/NixOS/nixpkgs/commit/9df9ad01b729e51982e1925f632bd35572ec3117) | `` gl-gsync-demo: fix invalid unstable version scheme ``                                         |
| [`2033be9e`](https://github.com/NixOS/nixpkgs/commit/2033be9e05e9945471c683d1eb5628a7b3ed71c6) | `` python3Packages.jsonmerge: modernize ``                                                       |
| [`128c4f1f`](https://github.com/NixOS/nixpkgs/commit/128c4f1f95d1bd660f22b271b68efc47d7a389df) | `` python3Packages.jsonmerge: migrate to pyproject ``                                            |
| [`236411a2`](https://github.com/NixOS/nixpkgs/commit/236411a29f1dee87655ee7af18c2144906eabcd6) | `` froide: pin working django-oauth-toolkit version ``                                           |
| [`3d42d5bd`](https://github.com/NixOS/nixpkgs/commit/3d42d5bd6aaf9d2376a89ebba36a0017795c644f) | `` python3Packages.xstatic-font-awesome: fix homepage ``                                         |
| [`f40e7b08`](https://github.com/NixOS/nixpkgs/commit/f40e7b08d3e13d1fea189af72f1e3eb7f1f095d4) | `` yafetch: Fix invalid unstable version scheme ``                                               |
| [`329082d1`](https://github.com/NixOS/nixpkgs/commit/329082d1247b40ca7cba80055855a0f0d8697738) | `` nufmt: 0-unstable-2026-07-23 -> 0-unstable-2026-08-12 ``                                      |
| [`dc8146a5`](https://github.com/NixOS/nixpkgs/commit/dc8146a5631c4c559f42709e6923ef7b4de03424) | `` terraform-providers.huaweicloud_huaweicloud: 1.96.1 -> 1.97.1 ``                              |
| [`b362b947`](https://github.com/NixOS/nixpkgs/commit/b362b947e57cedea23bd82a85dc8d7f5adf8564e) | `` github-copilot-app: init at 1.1.11 ``                                                         |
| [`31055299`](https://github.com/NixOS/nixpkgs/commit/31055299d7cf12add314396f6870fc05bf698eb4) | `` labwc: 0.20.1 -> 0.20.2 ``                                                                    |
| [`1468c692`](https://github.com/NixOS/nixpkgs/commit/1468c69235bc7bc6d013530f43a07b60721b3ceb) | `` quark: Fix invalid unstable version scheme ``                                                 |
| [`582eaa82`](https://github.com/NixOS/nixpkgs/commit/582eaa82f2a9b3a2c21bac2d23bb8e829c5ff556) | `` ungoogled-chromium: 151.0.7922.169-1 -> 151.0.7922.173-1 ``                                   |
| [`572814f1`](https://github.com/NixOS/nixpkgs/commit/572814f122b4b2f375e2b11e166cc94d7e97cfd9) | `` beamPackages.lfe: 2.2.0 -> 2.2.2 ``                                                           |
| [`3e7bc0a3`](https://github.com/NixOS/nixpkgs/commit/3e7bc0a3e6d1952b46ffdeb889866d25cad28a14) | `` beamPackages.expert: 0.1.8 -> 0.1.9 ``                                                        |
| [`5899011f`](https://github.com/NixOS/nixpkgs/commit/5899011f4f04d85b2e28d3eb3ed3b9bda98ab2e3) | `` nginxModules.lua: add nixosTests.nginx-lua to passthru.tests ``                               |
| [`0ca3e541`](https://github.com/NixOS/nixpkgs/commit/0ca3e541aaaec2bd0c43f38fe8cca38740bea499) | `` kubeshark: 53.3.0 -> 53.4.0 ``                                                                |
| [`69796c0e`](https://github.com/NixOS/nixpkgs/commit/69796c0e780e0e724b90f172223d882311a299cd) | `` python3Packages.llama-index-workflows: 2.23.0 -> 2.23.2 ``                                    |
| [`14a6664e`](https://github.com/NixOS/nixpkgs/commit/14a6664e9084cb8d99b00ab3c866d58f6ba680ff) | `` netbird: 0.77.0 -> 0.77.1 ``                                                                  |
| [`d87ce8e7`](https://github.com/NixOS/nixpkgs/commit/d87ce8e70936a750fd4272a09832e4336a13dd96) | `` schemacrawler: 17.12.2 -> 17.14.0 ``                                                          |
| [`4326adcd`](https://github.com/NixOS/nixpkgs/commit/4326adcdcf0eb52931dcd65234a731009a2bf073) | `` maia3: document postPatch ``                                                                  |
| [`66c12d70`](https://github.com/NixOS/nixpkgs/commit/66c12d70c1fb7d12686ffd81866e648823fae844) | `` vrcx: electron_41 -> electron_42 ``                                                           |
| [`1acb7001`](https://github.com/NixOS/nixpkgs/commit/1acb700162ea3e4e791b207436ca9835bfb9f616) | `` par-lang: 0-unstable-2026-07-29 -> 0-unstable-2026-08-20 ``                                   |
| [`5acbc090`](https://github.com/NixOS/nixpkgs/commit/5acbc090bbdf262b0a0be6d580840483ade0705c) | `` gccNGPackages.libgfortran: Fix patch conflict with `system-libbacktrace` ``                   |
| [`c7c777c2`](https://github.com/NixOS/nixpkgs/commit/c7c777c24e2d6735e5319e7ff66a1e136f6423d7) | `` python3Packages.tt-flash: relax pyluwen ``                                                    |
| [`26523b4c`](https://github.com/NixOS/nixpkgs/commit/26523b4c828f98c36d2b5ab0ef41bdc4bf4e19ba) | `` nixos/moonshine: init ``                                                                      |
| [`22488105`](https://github.com/NixOS/nixpkgs/commit/2248810528f55d7881557b0d783455de2a304544) | `` tt-topology: migrate to finalAttrs ``                                                         |
| [`c8de0e90`](https://github.com/NixOS/nixpkgs/commit/c8de0e90482f0b24cfe440a5a3f98ab9430ce7d1) | `` tt-topology: relax pyluwen ``                                                                 |
| [`94e6da09`](https://github.com/NixOS/nixpkgs/commit/94e6da094c2f13ed5a7082282630b6f97186055c) | `` tt-smi: 6.2.0 -> 6.2.1 ``                                                                     |
| [`55b7e752`](https://github.com/NixOS/nixpkgs/commit/55b7e7524c1ce81fde76a3c63b952bd27b94dbd3) | `` getsploit: init at 3.0.1 ``                                                                   |
| [`0528b19e`](https://github.com/NixOS/nixpkgs/commit/0528b19e590fb6a441a1e7df26c66af239973857) | `` shelfmark: 1.3.9 -> 1.3.11 ``                                                                 |
| [`bc156c59`](https://github.com/NixOS/nixpkgs/commit/bc156c59cf40f374fb7347bea93870eb7ae79ec2) | `` zellijPlugins.vim-zellij-navigator: fix build on darwin ``                                    |

*... and 4865 more commits (truncated)*