### PR TITLE
chore(flake/nixpkgs): `56c02bc0` -> `83199d0d`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -58,11 +58,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1787498568,
-        "narHash": "sha256-9i/VTdusq/+NM/tz+J1Re+ojkMB8MBf0QshnYfzHz30=",
+        "lastModified": 1787900134,
+        "narHash": "sha256-VYXO0XZlgj06dxJZRhrD3WoSsvq/c7+/Akyoa22pefw=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "56c02bc00adcf003215cc4bd996d6efaf4cff188",
+        "rev": "83199d0d373dd3ac2b9a1996b1d0263f76ab7a4c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                         |
| ---------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------- |
| [`68e80f3d`](https://github.com/NixOS/nixpkgs/commit/68e80f3d5bbfcc162c145c784cff0d86bb66efc6) | `` terraform-providers.vancluever_acme: 2.48.3 -> 3.0.0 ``                                      |
| [`3cc7a219`](https://github.com/NixOS/nixpkgs/commit/3cc7a21921ff4bbaa5295cb57d611b4437dc5ba3) | `` gccNGPackages: use `mcfgthreads` for threading on MinGW ``                                   |
| [`f33fe1c5`](https://github.com/NixOS/nixpkgs/commit/f33fe1c5643d4f5e4e9a138c231a7e613b937aed) | `` windows: build the threading libraries with `gccNGPackages` where that set is in use ``      |
| [`d606525b`](https://github.com/NixOS/nixpkgs/commit/d606525b15d877ffd7aee2eee3009173227cb6d8) | `` gccNGPackages.libgomp: only build where the threading model is pthreads ``                   |
| [`f54b73e9`](https://github.com/NixOS/nixpkgs/commit/f54b73e9cf5f9b9235cc8eb72b7df8e9bb2cf848) | `` gccNGPackages.libstdcxx: keep target-specific `gthr` headers in the source ``                |
| [`bd68a4ac`](https://github.com/NixOS/nixpkgs/commit/bd68a4ac1427c49d7171214b4fdfe41186cd9061) | `` windows: declare the thread models, and mark the headers-only libc ``                        |
| [`25a4331a`](https://github.com/NixOS/nixpkgs/commit/25a4331af51f0786f7eae62209d25fb140fa24c1) | `` python3Packges.scikit-base: migrate to finalAttrs ``                                         |
| [`1ba4ec33`](https://github.com/NixOS/nixpkgs/commit/1ba4ec33ebc3e36ea8f6067c7d77aff5e566676e) | `` incus-compose: 1.2.0 -> 1.3.1 ``                                                             |
| [`859b899f`](https://github.com/NixOS/nixpkgs/commit/859b899f80c70b71bce38444eeb05f5631fdeee7) | `` python3Packages.aiohomekit: migrate to finalAttrs ``                                         |
| [`2f277152`](https://github.com/NixOS/nixpkgs/commit/2f27715204304e1c44bda55017ea1e8223b1bb9d) | `` python3Packages.aiohomekit: 4.0.0 -> 4.0.1 ``                                                |
| [`9c1360b6`](https://github.com/NixOS/nixpkgs/commit/9c1360b601f303e596980427c943772f35817d4f) | `` python3Packages.cyclopts: 4.23.2 -> 4.23.3 ``                                                |
| [`6d17f5d8`](https://github.com/NixOS/nixpkgs/commit/6d17f5d82aeac59462b0b2979a2d0fb79be3bb19) | `` incus: 7.3.0 -> 7.4.0 ``                                                                     |
| [`137bc0fb`](https://github.com/NixOS/nixpkgs/commit/137bc0fbaf6dfb49755b58150565e5db209a3382) | `` open-webui: 0.11.0 -> 0.11.1 ``                                                              |
| [`65ab57f1`](https://github.com/NixOS/nixpkgs/commit/65ab57f182bdf92a7ecbf413e11f0df428e56edd) | `` python3Packages.google-cloud-datastore: 2.26.0 -> 2.26.1 ``                                  |
| [`aab3bb3e`](https://github.com/NixOS/nixpkgs/commit/aab3bb3eb19d102014960c28476da3b0790b4eb8) | `` incus-lts: backport 7.4 security fixes ``                                                    |
| [`e2ac6ddb`](https://github.com/NixOS/nixpkgs/commit/e2ac6ddb39dcbfcd98c301b163d4a83865adbf58) | `` python3Packages.pytest-skip-slow: init at 1.0 ``                                             |
| [`99a85538`](https://github.com/NixOS/nixpkgs/commit/99a855381d60908f5390cd41cdeb8efc6bac6401) | `` python3Packages.pyvicare: 2.61.0 -> 2.62.0 ``                                                |
| [`fd05e816`](https://github.com/NixOS/nixpkgs/commit/fd05e816514c7a36f4883ef8e0a3f804ea60c0f8) | `` terraform-providers.archessmn_powerdns: init at 1.0.6 ``                                     |
| [`16d51d89`](https://github.com/NixOS/nixpkgs/commit/16d51d89e62abdf1df48cf425426ba1459866b75) | `` woodpecker-{agent,cli,server}: 3.17.0 -> 3.18.0 ``                                           |
| [`1afaa51d`](https://github.com/NixOS/nixpkgs/commit/1afaa51d311e8d3b414ae8e1bbeb9c27602f7ef1) | `` python3Packages.scikit-base: 1.1.0 -> 1.1.1 ``                                               |
| [`c29d2212`](https://github.com/NixOS/nixpkgs/commit/c29d2212b335fbc8c3aefe354985374a5874876d) | `` python3Packages.alibabacloud-ram20150501: 1.2.1 -> 1.3.0 ``                                  |
| [`56422c09`](https://github.com/NixOS/nixpkgs/commit/56422c093208e9d0157b24fbfe399ba92b650793) | `` python3Packages.microsoft-kiota-serialization-text: 1.11.9 -> 1.12.0 ``                      |
| [`05dabe61`](https://github.com/NixOS/nixpkgs/commit/05dabe612dbf59f108b4064f08701a8787970f5c) | `` python3Packages.microsoft-kiota-serialization-multipart: 1.11.9 -> 1.12.0 ``                 |
| [`167c2556`](https://github.com/NixOS/nixpkgs/commit/167c2556b54715da7b67cb29498a38421e58a8e1) | `` python3Packages.microsoft-kiota-serialization-json: 1.11.9 -> 1.12.0 ``                      |
| [`d3975538`](https://github.com/NixOS/nixpkgs/commit/d3975538494e5db164d7bab9f6a568d459c74e17) | `` python3Packages.microsoft-kiota-serialization-form: 1.11.9 -> 1.12.0 ``                      |
| [`b1bf84ab`](https://github.com/NixOS/nixpkgs/commit/b1bf84abfec68b686c02f0899f749e10f3027f24) | `` python3Packages.microsoft-kiota-http: 1.11.9 -> 1.12.0 ``                                    |
| [`c2b84f54`](https://github.com/NixOS/nixpkgs/commit/c2b84f5443973a2d7e2439799bacf7faaf78a313) | `` python3Packages.microsoft-kiota-authentication-azure: 1.11.9 -> 1.12.0 ``                    |
| [`4a3024b6`](https://github.com/NixOS/nixpkgs/commit/4a3024b66dc717cfae7b163fb7bc265338f0187b) | `` python3Packages.microsoft-kiota-abstractions: 1.11.9 -> 1.12.0 ``                            |
| [`c1a64735`](https://github.com/NixOS/nixpkgs/commit/c1a64735a5ee54b2ea3a55dc84a9742cf2ba2ee3) | `` javaPackages.compiler.openjdk17: 17.0.20+8 -> 17.0.20.1+1 ``                                 |
| [`845b6f75`](https://github.com/NixOS/nixpkgs/commit/845b6f7566b6b4d0a2d6570b5419b34aff7dfa77) | `` python3Packages.nest-asyncio2: init at 1.7.2 ``                                              |
| [`b7b356b4`](https://github.com/NixOS/nixpkgs/commit/b7b356b49e65c03a2e96458336a22cfdf10eb639) | `` python3Packages.smartthings-local: 0.1.8 -> 0.1.10 ``                                        |
| [`37a3c2ef`](https://github.com/NixOS/nixpkgs/commit/37a3c2effb2e1e83fdb30b7dc0a872db25d4eff1) | `` sioyek: 2.0.0-unstable-2026-08-17 -> 2.0.0-unstable-2026-08-18 ``                            |
| [`7f9f51c6`](https://github.com/NixOS/nixpkgs/commit/7f9f51c61598c1446feb52fdca772e1be72f1b3f) | `` home-assistant-custom-lovelace-modules.weather-radar-card: 3.7.3 -> 3.9.0 ``                 |
| [`8211cca3`](https://github.com/NixOS/nixpkgs/commit/8211cca3bebb5dd5b49fad1ef0dc47ebbc856c16) | `` home-assistant-custom-components.mass-queue: 0.10.3 -> 0.10.4 ``                             |
| [`7e46d964`](https://github.com/NixOS/nixpkgs/commit/7e46d964a3e6feed8cb656c363928a639e5eb43e) | `` python3Packages.types-webencodings: 0.5.0.20260408 -> 0.6.0.20260827 ``                      |
| [`1db923ff`](https://github.com/NixOS/nixpkgs/commit/1db923ff8ad1fa5081bb5d465d1d1573d82a944c) | `` noctalia: 5.0.0-beta.9 -> 5.0.0-beta.10 ``                                                   |
| [`8a01d524`](https://github.com/NixOS/nixpkgs/commit/8a01d52436cbf821ea0991b1f9d6b4c845edacda) | `` discordchatexporter-cli: 2.47.3 -> 2.48 ``                                                   |
| [`4093442b`](https://github.com/NixOS/nixpkgs/commit/4093442be1fe7899864b6c961128dc42b4bae4e6) | `` nixos/frigate: exclude python multiprocessing sockets from tmpfiles ``                       |
| [`d9ea3b12`](https://github.com/NixOS/nixpkgs/commit/d9ea3b121d50bc3f6598298f745a6a18d69e9b0a) | `` tcl: use finalAttrs, use let binding instead of rec ``                                       |
| [`28929d23`](https://github.com/NixOS/nixpkgs/commit/28929d2336628d395c42584f99e7b95843ebae32) | `` tetragon: 1.7.0 -> 1.7.1 ``                                                                  |
| [`a690be13`](https://github.com/NixOS/nixpkgs/commit/a690be13617e61abd99b883d39d56cf4f27f811e) | `` tcl: Give Cygwin the import library it says it has ``                                        |
| [`c4e696e4`](https://github.com/NixOS/nixpkgs/commit/c4e696e4919b5138c09557b89ea7c960bd04683a) | `` argo-rollouts: 1.9.1 -> 1.10.0 ``                                                            |
| [`7c72f585`](https://github.com/NixOS/nixpkgs/commit/7c72f585a09c25e46f7e4d128053a1fc339e5cd8) | `` gimagereader: unstable-2025-06-04 -> 3.4.3, use podofo 1.x ``                                |
| [`7a083e1f`](https://github.com/NixOS/nixpkgs/commit/7a083e1fa87499b1e6706128f7232495a07a6ec6) | `` gimagereader: finalAttrs, remove wrapQtAppsHook ``                                           |
| [`3c85327c`](https://github.com/NixOS/nixpkgs/commit/3c85327c3e7fb37b7ce57d91b7131997c9710884) | `` testSignedPackages.shim-signed: init ``                                                      |
| [`f46d7676`](https://github.com/NixOS/nixpkgs/commit/f46d7676dbd9ddd45b3a4474373dfc916f16bc80) | `` testSignedPackages.systemd-boot-signed: init ``                                              |
| [`452def58`](https://github.com/NixOS/nixpkgs/commit/452def58573597b597d342bf80d13a0e4f478be6) | `` testSignedPackages.fwupd-efi-signed: init ``                                                 |
| [`7737bc42`](https://github.com/NixOS/nixpkgs/commit/7737bc42a552dbdfebb7449505f9ace21497a163) | `` testSignedPackages: init ``                                                                  |
| [`4bb9adb7`](https://github.com/NixOS/nixpkgs/commit/4bb9adb77c3efc84257202a4f7a9a7bf2bc053c4) | `` mkSignedPackages: init ``                                                                    |
| [`49b0b89e`](https://github.com/NixOS/nixpkgs/commit/49b0b89ecc653f0bf1e5dd8d36b5606c9ce335a6) | `` authenticodeCheckHook: init ``                                                               |
| [`d29ae162`](https://github.com/NixOS/nixpkgs/commit/d29ae1620557ba5bb56f22f1c5c1916feebddba3) | `` ad: 0.3.1 -> 0.4.0 ``                                                                        |
| [`34493d22`](https://github.com/NixOS/nixpkgs/commit/34493d223e2246c41b062306c3863260d93506ed) | `` yopass: fix the hash ``                                                                      |
| [`914ae55a`](https://github.com/NixOS/nixpkgs/commit/914ae55ad8a70ecfb5b894fea2d2badf54e03bc8) | `` autopen: init at 0.2.0 ``                                                                    |
| [`6ac8da4b`](https://github.com/NixOS/nixpkgs/commit/6ac8da4ba06d7ee4371a5b35a2faf3cda221f276) | `` fwupd-efi: add description ``                                                                |
| [`6367ec9e`](https://github.com/NixOS/nixpkgs/commit/6367ec9e42d7d78c1dc375a496d7c117ee38fdf3) | `` maintainers/team-list: add boot security team ``                                             |
| [`572b8383`](https://github.com/NixOS/nixpkgs/commit/572b8383aff8e25b5686f8f3d85f8272b9559d89) | `` fwupd-efi: inherit metadata from `fwupd` ``                                                  |
| [`50a3a38d`](https://github.com/NixOS/nixpkgs/commit/50a3a38d5dc56e0c264c4382e602232cbc0fbc20) | `` fwupd-efi: add boot security team to maintainers ``                                          |
| [`60ea7d6d`](https://github.com/NixOS/nixpkgs/commit/60ea7d6de901ced6dfc491a2a8a502dd3428bcf8) | `` shim-unsigned: add boot security team to maintainers ``                                      |
| [`2b871c47`](https://github.com/NixOS/nixpkgs/commit/2b871c473968cfc41643b6e74eddbf2498efd9ba) | `` autopen: add Nix signing utilities ``                                                        |
| [`6ede6973`](https://github.com/NixOS/nixpkgs/commit/6ede697335a3445e725d663844e274aba9e5df0b) | `` entt: 3.14.0 -> 3.16.0 ``                                                                    |
| [`1c747334`](https://github.com/NixOS/nixpkgs/commit/1c74733467142e147ea0649cae6145d965508c55) | `` texlive.bin.pygmentex: fix typo in alias ``                                                  |
| [`4a80f4f1`](https://github.com/NixOS/nixpkgs/commit/4a80f4f1d49feb29106ce1911c0ac1354f9fa2a1) | `` memos: 0.29.1 -> 0.30.0 ``                                                                   |
| [`a431d4dd`](https://github.com/NixOS/nixpkgs/commit/a431d4dd1624cc23a56dc6a647460d2249c3a24b) | `` amnezia-vpn: 4.8.21.0 -> 5.0.0.5 ``                                                          |
| [`3494bd71`](https://github.com/NixOS/nixpkgs/commit/3494bd71b54894ce5af407da692d0112e8c1b1ef) | `` glaze: 8.1.0 -> 8.2.0 ``                                                                     |
| [`27af1711`](https://github.com/NixOS/nixpkgs/commit/27af1711b585ef797199b8138cdc54743995918a) | `` nats-server: 2.14.5 -> 2.14.6 ``                                                             |
| [`39708d4a`](https://github.com/NixOS/nixpkgs/commit/39708d4ad54dce99da21ec0c8218e8d1358ffe17) | `` rcu: 5.1.0 -> 5.1.1 ``                                                                       |
| [`2dd8d32d`](https://github.com/NixOS/nixpkgs/commit/2dd8d32dcf76967680166415c90075674fc0807b) | `` ungoogled-chromium: 151.0.7922.173-1 -> 152.0.7977.64-1 ``                                   |
| [`4957deb9`](https://github.com/NixOS/nixpkgs/commit/4957deb9867a5f1482e31d130f55194f91496202) | `` python3Packages.xformers: fix Darwin build with CPU backend ``                               |
| [`60967516`](https://github.com/NixOS/nixpkgs/commit/609675167e4eefe68d91a9d4bfe0e1bfb20638b9) | `` python314Packages.impacket: removed openssl legacy override ``                               |
| [`a248a17e`](https://github.com/NixOS/nixpkgs/commit/a248a17e82f6d82db6fc44e242d043f9118c0d7d) | `` notmuch: fix build with emacs >= 31 ``                                                       |
| [`2ad17434`](https://github.com/NixOS/nixpkgs/commit/2ad1743479a65cf51a408d972fa957c0c550625a) | `` python3Packages.tomlrt: 2.2.3 -> 2.2.5 ``                                                    |
| [`0b062878`](https://github.com/NixOS/nixpkgs/commit/0b0628780dd86fafd6c5c7535688103625e23cb0) | `` olympus-unwrapped: 26.07.27.01 -> 26.08.24.03 ``                                             |
| [`1238af7d`](https://github.com/NixOS/nixpkgs/commit/1238af7d95889eba447ed3cc2bb80cff13f4bc3f) | `` cocoon: 0.10 -> 0.11.1 ``                                                                    |
| [`4b7caef7`](https://github.com/NixOS/nixpkgs/commit/4b7caef7f5844659ba9ed59f3f13019922ddb55d) | `` webanalyze: 0.4.3 -> 0.4.4 ``                                                                |
| [`efbf4c27`](https://github.com/NixOS/nixpkgs/commit/efbf4c2770950eb6ef78362f076ec02af3d79dcd) | `` python3Packages.oslo-db: 18.1.0 -> 18.1.1 ``                                                 |
| [`cf59671c`](https://github.com/NixOS/nixpkgs/commit/cf59671c2ba5e04c06829556d7f1aa8e5397b186) | `` vscode-extensions.visualjj.visualjj: 0.33.5 -> 0.33.6 ``                                     |
| [`059bf529`](https://github.com/NixOS/nixpkgs/commit/059bf52940921f3c328a36966f7913db284639c6) | `` bichon: 2.0.1 -> 2.0.2 ``                                                                    |
| [`451e996e`](https://github.com/NixOS/nixpkgs/commit/451e996e0f71ab34d22fa14f62bc303d66d5d11b) | `` eilmeldung: 1.7.2 -> 1.7.3 ``                                                                |
| [`26a12e9c`](https://github.com/NixOS/nixpkgs/commit/26a12e9c525162fc7bba6a945dc7aabd08914611) | `` gitpulsar: init at 1.3.1 ``                                                                  |
| [`8fb77c31`](https://github.com/NixOS/nixpkgs/commit/8fb77c31371ec999544e4192f6209be25e9b9189) | `` vector: 0.57.0 -> 0.58.0 ``                                                                  |
| [`4006c6b7`](https://github.com/NixOS/nixpkgs/commit/4006c6b7954811841ef7a844aa67c7f0094e01f8) | `` badness: 0.16.0 -> 0.20.0 ``                                                                 |
| [`964592c6`](https://github.com/NixOS/nixpkgs/commit/964592c656015949d352e0939d404d3885667852) | `` javaPackages.compiler.openjdk25: 25.0.4+7 -> 25.0.4.1+1 ``                                   |
| [`906422d7`](https://github.com/NixOS/nixpkgs/commit/906422d7dc6cc7f859750cdbadfaa388dd09b813) | `` pitchfork: remove unused 3 dots ``                                                           |
| [`1f48af59`](https://github.com/NixOS/nixpkgs/commit/1f48af598978461513703805175face70df8822f) | `` pgschema: removed commented code ``                                                          |
| [`a3d20154`](https://github.com/NixOS/nixpkgs/commit/a3d20154eed4b2170314bba55ddd83356f779f28) | `` linux_5_10: 5.10.266 -> 5.10.267 ``                                                          |
| [`213f59ec`](https://github.com/NixOS/nixpkgs/commit/213f59ec5f06e2eaec0b45390b75275c00f86fe5) | `` linux_5_15: 5.15.217 -> 5.15.218 ``                                                          |
| [`de42cfab`](https://github.com/NixOS/nixpkgs/commit/de42cfab7ba4dddda22e8154f9861aa5424b0d4f) | `` linux_6_1: 6.1.184 -> 6.1.185 ``                                                             |
| [`77803f5d`](https://github.com/NixOS/nixpkgs/commit/77803f5df70ff08b24db948ff4d232053c4fea0e) | `` linux_6_6: 6.6.153 -> 6.6.154 ``                                                             |
| [`2527a96f`](https://github.com/NixOS/nixpkgs/commit/2527a96fefdd33305a3d020c7303b541c7e4fcd0) | `` linux_6_12: 6.12.105 -> 6.12.106 ``                                                          |
| [`5f8a9ee2`](https://github.com/NixOS/nixpkgs/commit/5f8a9ee2d608b9d6a3f349f6ea6b7c98b0d9c9a4) | `` linux_6_18: 6.18.46 -> 6.18.47 ``                                                            |
| [`f1c736c8`](https://github.com/NixOS/nixpkgs/commit/f1c736c81b500c9c9f132da3121c6986307abe69) | `` linuxPackages.amneziawg: 3.1.20260812 -> 3.1.20260827 ``                                     |
| [`aae95aaa`](https://github.com/NixOS/nixpkgs/commit/aae95aaa5f8bf4dc3d6dc9c273cefea329430fdc) | `` linux_7_1: 7.1.10 -> 7.1.11 ``                                                               |
| [`87b52cf9`](https://github.com/NixOS/nixpkgs/commit/87b52cf9d5b30c7b472120ae56b4b6dbfdd6330b) | `` linux_7_2: 7.2 -> 7.2.1 ``                                                                   |
| [`781bf3df`](https://github.com/NixOS/nixpkgs/commit/781bf3df56538e66a81fc1a8312c5155db6c6ccb) | `` folia-major: 0.6.19 -> 0.7.0 ``                                                              |
| [`c95659cd`](https://github.com/NixOS/nixpkgs/commit/c95659cdd102fcddb320da19c09b1e9188d9881f) | `` python3Packages.pycflow2dot: fix build ``                                                    |
| [`e3cfdb2f`](https://github.com/NixOS/nixpkgs/commit/e3cfdb2f060ee80e3655376d40a90dd24ab4ae9a) | `` lilypond: enable structuredAttrs ``                                                          |
| [`cbf5c786`](https://github.com/NixOS/nixpkgs/commit/cbf5c7866dbc6ee5a200b5cc940dee843c38d806) | `` librechat: 0.8.6 -> 0.8.7 ``                                                                 |
| [`0e9a5ec5`](https://github.com/NixOS/nixpkgs/commit/0e9a5ec52e470d0e207bccb7e0e4ce102e996043) | `` tomat: 2.11.0 -> 2.12.0 ``                                                                   |
| [`0e21ffae`](https://github.com/NixOS/nixpkgs/commit/0e21ffaea07c45edcfdf9ba2e4765928c8eda9ca) | `` libphonenumber: 9.0.37 -> 9.0.38 ``                                                          |
| [`f01ce79a`](https://github.com/NixOS/nixpkgs/commit/f01ce79aecd8e59ab8a5e1fa2c2d66c224427c22) | `` lib/modules: inline errorContext string in applyModuleArgs ``                                |
| [`1b108c39`](https://github.com/NixOS/nixpkgs/commit/1b108c399a971a4795c57d09dab48ea7fce0de01) | `` xremap: 0.15.11 -> 0.15.12 ``                                                                |
| [`20366e43`](https://github.com/NixOS/nixpkgs/commit/20366e43df511389182676700808a7c42c283849) | `` root: 6.40.00 -> 6.40.04 ``                                                                  |
| [`c06e6ff4`](https://github.com/NixOS/nixpkgs/commit/c06e6ff426287f3c02ee1d61243bb295b0e4ed3b) | `` python3Packages.exa-py: 2.18.1 -> 2.19.0 ``                                                  |
| [`4bed936b`](https://github.com/NixOS/nixpkgs/commit/4bed936b7a860d46769d59536e8527fcbf683d9c) | `` ctx7: 0.5.8 -> 0.5.9 ``                                                                      |
| [`9c6a0d4b`](https://github.com/NixOS/nixpkgs/commit/9c6a0d4b3e8f0ab2399da48039815ffc76d09e1d) | `` terraform-providers.sumologic_sumologic: 3.3.0 -> 3.3.1 ``                                   |
| [`95a30bbf`](https://github.com/NixOS/nixpkgs/commit/95a30bbf10dd8c38c6b8b22aa7ce0518c2feea0e) | `` terraform-providers.spotinst_spotinst: 1.240.0 -> 1.241.0 ``                                 |
| [`00688dc2`](https://github.com/NixOS/nixpkgs/commit/00688dc2c47049d2216154a7da27a1f66f1754e2) | `` niks3: 1.8.0 -> 1.9.0 ``                                                                     |
| [`2306650f`](https://github.com/NixOS/nixpkgs/commit/2306650fff36c49b42ac5a0fab2319ae3a239b96) | `` nushellPlugins.skim: 0.29.1 -> 0.30.0 ``                                                     |
| [`394e9475`](https://github.com/NixOS/nixpkgs/commit/394e947512662ae4ddb00c6bf2ce9820551e1be6) | `` nushellPlugins.bson: mark broken ``                                                          |
| [`422bd5f9`](https://github.com/NixOS/nixpkgs/commit/422bd5f9a9197713b27d5b078906b7a161fd2a61) | `` nushellPlugins.dbus: update broken comment ``                                                |
| [`9d543958`](https://github.com/NixOS/nixpkgs/commit/9d543958c27ccc657d7544632b90b98515f494c2) | `` nushellPlugins.highlight: mark broken ``                                                     |
| [`c132f4a0`](https://github.com/NixOS/nixpkgs/commit/c132f4a0b426b35534b355380a98e1bdca877738) | `` nushellPlugins.semver: remove as deprecated ``                                               |
| [`8bde2444`](https://github.com/NixOS/nixpkgs/commit/8bde2444d12ed08f60a51bf340afa3082c357721) | `` nushellPlugins.units: mark broken ``                                                         |
| [`8dc89315`](https://github.com/NixOS/nixpkgs/commit/8dc89315a2f62fa3216ec5e6eb4dc5461c6a85e3) | `` nushellPlugins.net: mark broken ``                                                           |
| [`824a4b90`](https://github.com/NixOS/nixpkgs/commit/824a4b90df26d8487e6283c1227d28686a509e9d) | `` nushellPlugins: add compatibility tests ``                                                   |
| [`49c7875d`](https://github.com/NixOS/nixpkgs/commit/49c7875dacdd1671d48230d8ff182b0f3f55371c) | `` fluxcd-operator-mcp: 0.58.0 -> 0.58.1 ``                                                     |
| [`f5fabc4f`](https://github.com/NixOS/nixpkgs/commit/f5fabc4f1f84e5f87ea74927efb7a4a3db910c84) | `` ananicy-rules-cachyos: 0-unstable-2026-08-05 -> 0-unstable-2026-08-24 ``                     |
| [`ece60c61`](https://github.com/NixOS/nixpkgs/commit/ece60c611b9915bd6dcb62d6b17f0f323b203ac3) | `` emacs30, emacs30-macport: patch CVE-2026-79992 ``                                            |
| [`b0b3853b`](https://github.com/NixOS/nixpkgs/commit/b0b3853b8455324d7bd8a545da42652257f1c8d2) | `` python3Packages.boto3-stubs: 1.43.80 -> 1.43.81 ``                                           |
| [`c68d64b3`](https://github.com/NixOS/nixpkgs/commit/c68d64b3690e22834bf2847dab44e8f4640a8941) | `` python3Packages.mypy-boto3-sagemaker: 1.43.76 -> 1.43.81 ``                                  |
| [`7e73a12e`](https://github.com/NixOS/nixpkgs/commit/7e73a12ed6757d836057d6668f4b4f5ab61ffa8b) | `` python3Packages.mypy-boto3-network-firewall: 1.43.63 -> 1.43.81 ``                           |
| [`550569f8`](https://github.com/NixOS/nixpkgs/commit/550569f888acbe47b4714675e4d26176ba06d1a9) | `` python3Packages.mypy-boto3-license-manager-user-subscriptions: 1.43.0 -> 1.43.81 ``          |
| [`c5aec29e`](https://github.com/NixOS/nixpkgs/commit/c5aec29ef6a55f76fd036ed6ed40378580fe9a36) | `` python3Packages.mypy-boto3-ec2: 1.43.80 -> 1.43.81 ``                                        |
| [`e6579faf`](https://github.com/NixOS/nixpkgs/commit/e6579fafff782d17a8fe00f3ec247b61322e7ccd) | `` python3Packages.boto3-stubs: 1.43.79 -> 1.43.80 ``                                           |
| [`f34b4e95`](https://github.com/NixOS/nixpkgs/commit/f34b4e95bf3d8bd1fb676cdac2ba9b0cdeeed92e) | `` python3Packages.mypy-boto3-meteringmarketplace: 1.43.52 -> 1.43.80 ``                        |
| [`f92d4da6`](https://github.com/NixOS/nixpkgs/commit/f92d4da6c75e55543e2cfaaf77a58c9497faad6b) | `` python3Packages.mypy-boto3-iot: 1.43.20 -> 1.43.80 ``                                        |
| [`04bd3ea0`](https://github.com/NixOS/nixpkgs/commit/04bd3ea099dfd38e464b001ce7592c36a368f8b1) | `` python3Packages.mypy-boto3-eks: 1.43.75 -> 1.43.80 ``                                        |
| [`9b808eae`](https://github.com/NixOS/nixpkgs/commit/9b808eae09d3f99030107f27c9b9ae816f0f788c) | `` python3Packages.mypy-boto3-ec2: 1.43.76 -> 1.43.80 ``                                        |
| [`bbace52e`](https://github.com/NixOS/nixpkgs/commit/bbace52e3822ba3edba92592bcb4fd5480f65890) | `` python3Packages.mypy-boto3-autoscaling: 1.43.71 -> 1.43.80 ``                                |
| [`771667ae`](https://github.com/NixOS/nixpkgs/commit/771667aeb1e1862c6a0a156d6f9b3897cfcb01e3) | `` bootdev-cli: 1.31.1 -> 1.32.1 ``                                                             |
| [`2ccccbb0`](https://github.com/NixOS/nixpkgs/commit/2ccccbb040eb9153a461c04b02e60cc2fe55f6c4) | `` retroshare: fix desktop entry ``                                                             |
| [`99ab4715`](https://github.com/NixOS/nixpkgs/commit/99ab47157a87dd50959f8b29fcddd8bde70b8ee9) | `` aptakube: 1.18.8 -> 1.19.3 ``                                                                |
| [`7c48e457`](https://github.com/NixOS/nixpkgs/commit/7c48e457e03d7ddcda8a535e9ccb151d1656e378) | `` Revert "huggingface: update" ``                                                              |
| [`e68e4cbc`](https://github.com/NixOS/nixpkgs/commit/e68e4cbcd319fc2b0a4b0352f3cade5010dd6c26) | `` python3Packages.tencentcloud-sdk-python: 3.1.165 -> 3.1.166 ``                               |
| [`06087f07`](https://github.com/NixOS/nixpkgs/commit/06087f07435dcde454ddb64ceb8184ac5cfbf91d) | `` python3Packages.iamdata: 0.1.202608261 -> 0.1.202608271 ``                                   |
| [`dccde518`](https://github.com/NixOS/nixpkgs/commit/dccde518a45fda73284c3c4772b6556337975805) | `` dusklight: fix aarch64 hash ``                                                               |
| [`cbc7163b`](https://github.com/NixOS/nixpkgs/commit/cbc7163bb869156576851d6f3147ded46b5bf8ab) | `` search-vulns: 1.2.4 -> 1.2.5 ``                                                              |
| [`606bc452`](https://github.com/NixOS/nixpkgs/commit/606bc4523a5da212f2c2033406c91bb2f41f9c02) | `` librewolf-unwrapped: switch to fetchFromForgejo ``                                           |
| [`7c2fd348`](https://github.com/NixOS/nixpkgs/commit/7c2fd348debc5fd7208d157d92dacf20d031ec41) | `` solaar: add Svenum as maintainer ``                                                          |
| [`cf20a506`](https://github.com/NixOS/nixpkgs/commit/cf20a5063a071d48d099c1dbbbea16317dab48c5) | `` amazon-ssm-agent: 3.3.5068.0 -> 3.3.5226.0 ``                                                |
| [`3f2d8cf3`](https://github.com/NixOS/nixpkgs/commit/3f2d8cf3a90de4129f50a9977b25e05065670ef2) | `` nixos/pgbackrest: drop wolfgangwalther as maintainer ``                                      |
| [`53b4b7cc`](https://github.com/NixOS/nixpkgs/commit/53b4b7cce73ac5a84271f4ce9f7e5d3672ced1d2) | `` yaziPlugins.sudo: 0-unstable-2026-08-23 → 0-unstable-2026-08-26 ``                           |
| [`fce1e302`](https://github.com/NixOS/nixpkgs/commit/fce1e30281146d6799d070eef57ef97c05c02b1f) | `` mango: 0.16.1 -> 0.16.2 ``                                                                   |
| [`8e5ab8f8`](https://github.com/NixOS/nixpkgs/commit/8e5ab8f853b59d5be26800810a9397b6d94973d2) | `` tabularis: 0.20.0 -> 0.21.0 ``                                                               |
| [`d5c312b7`](https://github.com/NixOS/nixpkgs/commit/d5c312b7663bb2638b91c0b44950ec60b7d32177) | `` ocamlPackages.mirage-crypto: 2.3.0 -> 2.4.1 ``                                               |
| [`34dfec22`](https://github.com/NixOS/nixpkgs/commit/34dfec22a740ba4885c70184c836fbb732aa6251) | `` python3Packages.prefect: 3.8.3 -> 3.8.4 ``                                                   |
| [`e7814344`](https://github.com/NixOS/nixpkgs/commit/e781434452c41ece81d08960a49409c420a7c176) | `` gvm-libs: 23.9.2 -> 23.9.3 ``                                                                |
| [`c3a57f0d`](https://github.com/NixOS/nixpkgs/commit/c3a57f0d5ce32ce19b8bc31f05fbdaa6792e7d5c) | `` gogup: 1.8.0 -> 1.8.1 ``                                                                     |
| [`975a0cc1`](https://github.com/NixOS/nixpkgs/commit/975a0cc19e6223ce7dcc947cdd8bb6c2c1fe7e6f) | `` skills: 1.5.22 -> 1.5.23 ``                                                                  |
| [`b332cd77`](https://github.com/NixOS/nixpkgs/commit/b332cd778f820360dc5344705764df735a943c2f) | `` ggml: 0.20.1 -> 0.22.0 ``                                                                    |
| [`45d1a7de`](https://github.com/NixOS/nixpkgs/commit/45d1a7de8571813812897a8cf38f6db742203914) | `` vencord: 1.15.1 -> 1.15.3 ``                                                                 |
| [`b48bca5f`](https://github.com/NixOS/nixpkgs/commit/b48bca5f3e5757a10082b87558eba05d11245754) | `` libretro.genesis-plus-gx: 0-unstable-2026-08-14 -> 0-unstable-2026-08-21 ``                  |
| [`4b8f1120`](https://github.com/NixOS/nixpkgs/commit/4b8f112095187b8eb61171d35129b7ba03c695dc) | `` rusthound-ce: 2.5.1 -> 2.5.5 ``                                                              |
| [`2eb6271b`](https://github.com/NixOS/nixpkgs/commit/2eb6271bb6da860d5df03fdaf737cfbeeaad43b2) | `` python3Packages.aqualogic: 3.8 -> 3.9 ``                                                     |
| [`7dd122b2`](https://github.com/NixOS/nixpkgs/commit/7dd122b2b606cae52bed17433d2be7aebfa75b59) | `` ty: 0.0.74 -> 0.0.75 ``                                                                      |
| [`152688cc`](https://github.com/NixOS/nixpkgs/commit/152688ccabe42141bf0f8e4837755f3da4fe43f6) | `` cargo-zigbuild: 0.23.0 -> 0.23.2 ``                                                          |
| [`b037ad68`](https://github.com/NixOS/nixpkgs/commit/b037ad68bf9df49bbbb8a8120becd66acd5d5706) | `` go-mockery: 3.7.2 -> 3.7.4 ``                                                                |
| [`74865bb4`](https://github.com/NixOS/nixpkgs/commit/74865bb41c32caf0c141d3a9570186836ca78b06) | `` dnscontrol: 4.46.0 -> 5.0.0 ``                                                               |
| [`d43e2000`](https://github.com/NixOS/nixpkgs/commit/d43e2000468da901324b8f2c5e6d4f0e5bb3382b) | `` wavelog: enable strictDeps, __structuredAttrs ``                                             |
| [`2705082f`](https://github.com/NixOS/nixpkgs/commit/2705082f7ffaee598fdf2e82b576c0575723a11c) | `` libretro.nxengine: 0-unstable-2026-04-09 -> 0-unstable-2026-08-22 ``                         |
| [`8770da6a`](https://github.com/NixOS/nixpkgs/commit/8770da6abbdc31800c75eb772190e9fe1e8f26c8) | `` ldap-manager: 1.5.1 -> 1.6.0 ``                                                              |
| [`4118fe22`](https://github.com/NixOS/nixpkgs/commit/4118fe2269bb473f7334e0a5c35b02893c6f319d) | `` ctlptl: 0.9.4 -> 0.9.5 ``                                                                    |
| [`9e4abe5b`](https://github.com/NixOS/nixpkgs/commit/9e4abe5b1d8e3493b4276d83bd413d2c1feac987) | `` libretro.fceumm: 0-unstable-2026-07-28 -> 0-unstable-2026-08-22 ``                           |
| [`df59a28b`](https://github.com/NixOS/nixpkgs/commit/df59a28b2e484740fdd070a9181ceb52e971541e) | `` terraform-providers.lxc_incus: 1.1.1 -> 1.2.0 ``                                             |
| [`abb740b0`](https://github.com/NixOS/nixpkgs/commit/abb740b022f9adfb5af6b908f7989dc6e9ad9da3) | `` neo-cowsay: fix license ``                                                                   |
| [`3fd1979f`](https://github.com/NixOS/nixpkgs/commit/3fd1979f162587cf3ddf676fdef1e5945af712f5) | `` qpwgraph: 1.0.3 -> 1.0.4 ``                                                                  |
| [`a20bba75`](https://github.com/NixOS/nixpkgs/commit/a20bba753fa331a179b2773de29c49df8f5c0765) | `` feh: 3.12.2 -> 3.12.3 ``                                                                     |
| [`6b4dcf22`](https://github.com/NixOS/nixpkgs/commit/6b4dcf225606ac94026735426566a1fe42346a2e) | `` notesnook: fix `sourceRoot` for darwin systems ``                                            |
| [`e4ed5b28`](https://github.com/NixOS/nixpkgs/commit/e4ed5b28bf04c571f719ee6d03ec5a1615b3aea4) | `` pcmanfm-qt: 2.4.0 -> 2.4.1 ``                                                                |
| [`df78b1d9`](https://github.com/NixOS/nixpkgs/commit/df78b1d96b5f5c660d629717311c1182bcb4356d) | `` ramalama: add smoke tests for all supported backends ``                                      |
| [`7e73009f`](https://github.com/NixOS/nixpkgs/commit/7e73009fc34a0ee2f36d9aa41c4f2f91d9a0fae2) | `` openapi-generator-cli: 7.24.0 -> 7.25.0 ``                                                   |
| [`85a2d094`](https://github.com/NixOS/nixpkgs/commit/85a2d09403c300def0cc67b43958fee7a9b51837) | `` wrangler: 4.125.0 -> 4.126.0 ``                                                              |
| [`06aed552`](https://github.com/NixOS/nixpkgs/commit/06aed5520729437cdd117b134f5169486147ef86) | `` noctalia: fix build on musl ``                                                               |
| [`feb5a926`](https://github.com/NixOS/nixpkgs/commit/feb5a926b77732f7ef5ce72e333c9ecc0909a864) | `` top-level: drop res and super arguments from all-packages.nix ``                             |
| [`42077334`](https://github.com/NixOS/nixpkgs/commit/4207733405a80f4d94a7b0cbc658336b033d7566) | `` libxml2Python: move to pkgs/by-name ``                                                       |
| [`83f200df`](https://github.com/NixOS/nixpkgs/commit/83f200df0497900e307270214b5021364ae485a9) | `` terraform-providers.launchdarkly_launchdarkly: 3.1.3 -> 3.1.4 ``                             |
| [`b908b68a`](https://github.com/NixOS/nixpkgs/commit/b908b68a5ef6b31ec7477b8789acaddee7d9e6aa) | `` hockeypuck: 2.3.3 -> 2.4 ``                                                                  |
| [`25e9a9c3`](https://github.com/NixOS/nixpkgs/commit/25e9a9c389d65a699395e7a701d1db1883336617) | `` open62541pp: 0.21.2 -> 0.21.3 ``                                                             |
| [`3ce269e3`](https://github.com/NixOS/nixpkgs/commit/3ce269e395eca522f796c1320e74a5fc9a745d76) | `` python3Packages.pysilero-vad: unbreak on darwin ``                                           |
| [`1ab5465e`](https://github.com/NixOS/nixpkgs/commit/1ab5465e5ac5ce7bb00ba5dcad32d1586face4f4) | `` the-foundation: 1.12.2 → 1.13.1 ``                                                           |
| [`56a7b4b4`](https://github.com/NixOS/nixpkgs/commit/56a7b4b4005ae8bed2d1946daceff5ffa9f23b06) | `` nixos/doc: Improve the configuration/adding-custom-packages chapter ``                       |
| [`a1d76873`](https://github.com/NixOS/nixpkgs/commit/a1d768735ddede04d36c711e1d25e08b53ed3471) | `` cbonsai: enable strictDeps & __structuredAttrs, use tag for fetcher, adopt ``                |
| [`227b7ffc`](https://github.com/NixOS/nixpkgs/commit/227b7ffc599fa44b587561f7e0691b56d2d43254) | `` nodejs_26: 26.8.0 -> 26.8.1 ``                                                               |
| [`5ecdd258`](https://github.com/NixOS/nixpkgs/commit/5ecdd2582c02e7aedb929e30674c7a1e363e2279) | `` google-chrome: add version check test ``                                                     |
| [`35f088fa`](https://github.com/NixOS/nixpkgs/commit/35f088fac8359e6b3adda29661c7740f34028a74) | `` eclair: 0.8.0 -> 0.14.2 ``                                                                   |
| [`6cca552e`](https://github.com/NixOS/nixpkgs/commit/6cca552e0d4c4923cb4bd5e4717685b8a1036aa6) | `` python3Packages.gurobipy: 13.0.2 -> 13.0.3 ``                                                |
| [`2d5f8220`](https://github.com/NixOS/nixpkgs/commit/2d5f82200b0e040b48e524a2052c1403be5435f3) | `` gurobi: 13.0.2 -> 13.0.3 ``                                                                  |
| [`91d722aa`](https://github.com/NixOS/nixpkgs/commit/91d722aaccbcf7c4a9b0e5c1401f4199ee5475e5) | `` firefox: select ffmpeg by the libavcodec each browser prefers ``                             |
| [`9ee31e2f`](https://github.com/NixOS/nixpkgs/commit/9ee31e2fef856da9351fc587c9faa32b8b86e08e) | `` lagrange: 1.20.9 -> 1.21.0 ``                                                                |
| [`351739e8`](https://github.com/NixOS/nixpkgs/commit/351739e82eeaa0cbcccaf7ca98988f2c44c13731) | `` bee: 2.8.1 -> 2.8.2 ``                                                                       |
| [`a0b3228f`](https://github.com/NixOS/nixpkgs/commit/a0b3228fe4e5a5c42b1ecb5c58fdb5f1b1962e78) | `` docker-credential-helpers: 0.9.8 -> 0.9.9 ``                                                 |
| [`3840c6f6`](https://github.com/NixOS/nixpkgs/commit/3840c6f648b278b7d57e3add5806b1a28015ea10) | `` haskell.compiler.ghc966DebianBinary: add loongarch64 team as maintainers ``                  |
| [`6c974ba2`](https://github.com/NixOS/nixpkgs/commit/6c974ba260e50d9c656d1714ad1e75b344ca55a6) | `` ghc: apply patch for LLVM backend split sections on loongarch64-linux ``                     |
| [`a23aa37d`](https://github.com/NixOS/nixpkgs/commit/a23aa37dcfb1b5fd758391f66e3a8d9226272088) | `` ghc: add GHCi enablement patches for loongarch64-linux ``                                    |
| [`51177954`](https://github.com/NixOS/nixpkgs/commit/51177954003e1abd5e6d372fe7540f6b8c2dcd81) | `` delly: add debtquity as maintainer ``                                                        |
| [`e2fed119`](https://github.com/NixOS/nixpkgs/commit/e2fed1195e63b8515ba8c0121ae912e664db4ef8) | `` delly: update `passthru.tests.simple` ``                                                     |
| [`8db75176`](https://github.com/NixOS/nixpkgs/commit/8db75176ca040c9d54967d305a34ec2d04301625) | `` delly: remove `postPatch` modification ``                                                    |
| [`a97576c5`](https://github.com/NixOS/nixpkgs/commit/a97576c50bb7e377edf25ca40f0ded4ccce01377) | `` delly: 2.1.0 -> 2.6.0 ``                                                                     |
| [`c5350a32`](https://github.com/NixOS/nixpkgs/commit/c5350a32e583572bdebdf3a1c63f32c837f06794) | `` python3Packages.transformers: 5.15.0 -> 5.16.1 ``                                            |
| [`30afa352`](https://github.com/NixOS/nixpkgs/commit/30afa3524c9d323d849b59490f883f057b61e21b) | `` python3Packages.huggingface-hub: 1.27.0 -> 1.28.0 ``                                         |
| [`093cac61`](https://github.com/NixOS/nixpkgs/commit/093cac61e98569228c0d8ff403cf1dd1e2bba597) | `` python3Packages.sentence-transformers: 5.7.0 -> 6.0.0 ``                                     |
| [`3a30da15`](https://github.com/NixOS/nixpkgs/commit/3a30da1547d9ddd4ba302911f7ee0bf70db7dbcf) | `` python3Packages.tokenizers: 0.22.2 -> 0.23.1 ``                                              |
| [`5c7fbc92`](https://github.com/NixOS/nixpkgs/commit/5c7fbc92c6ac36ba124c4b95891560a88b71502b) | `` tcl: Cross compile to MinGW and Cygwin ``                                                    |
| [`10a939ab`](https://github.com/NixOS/nixpkgs/commit/10a939abcda37fd997df4716911474ed86f54c15) | `` mathic: 1.4 -> 1.5 ``                                                                        |
| [`c610612b`](https://github.com/NixOS/nixpkgs/commit/c610612bca458276581d2cf4197cf6e70b932558) | `` rustic: 0.11.3 -> 0.11.4 ``                                                                  |
| [`9c78312f`](https://github.com/NixOS/nixpkgs/commit/9c78312f6efb00589de6f42de3b95f32110be201) | `` diamond: add debtquity as maintainer ``                                                      |
| [`3a162fce`](https://github.com/NixOS/nixpkgs/commit/3a162fce1a7d51719b9cc8a085d82f252fe94fec) | `` diamond: add sqlite to build inputs ``                                                       |
| [`04e101c6`](https://github.com/NixOS/nixpkgs/commit/04e101c6ac6cc4cf07704c4d7b159b4c2bcc4e75) | `` diamond: 2.1.16 -> 2.2.5 ``                                                                  |
| [`02f944d7`](https://github.com/NixOS/nixpkgs/commit/02f944d79cbb14327cef9803c4a140772389f653) | `` anda: 0.8.5 -> 0.8.7 ``                                                                      |
| [`bbc129a7`](https://github.com/NixOS/nixpkgs/commit/bbc129a765b561e3a7b6e73652662ac68730620e) | `` terraform-providers.hashicorp_vault: 5.10.1 -> 5.11.0 ``                                     |
| [`b9160644`](https://github.com/NixOS/nixpkgs/commit/b91606441cb5162ad1b3fc5d0594efc8711c4628) | `` arnis: 3.0.0 -> 3.1.0 ``                                                                     |
| [`74de58b5`](https://github.com/NixOS/nixpkgs/commit/74de58b5481e5c38f76c61947321cb4cd6c827c6) | `` blender: 5.2.0 -> 5.2.1 ``                                                                   |
| [`49f48efb`](https://github.com/NixOS/nixpkgs/commit/49f48efb6151753f79be2ef13ec2a0df5c22b152) | `` qir-runner: 0.8.3 -> 0.9.6 ``                                                                |
| [`4ae80f27`](https://github.com/NixOS/nixpkgs/commit/4ae80f2758212ac7f073a3f76690582c3ea45654) | `` inngest: 1.41.1 -> 1.43.0 ``                                                                 |
| [`8958184c`](https://github.com/NixOS/nixpkgs/commit/8958184c2fdee1bc5aa1e1033a8ee9e076b5c08d) | `` python3Packages.netbox-*: remove (moved to netboxPlugins package set) ``                     |
| [`73a6aa7c`](https://github.com/NixOS/nixpkgs/commit/73a6aa7c625a05acbd0d6e5a249fc30ba35acd28) | `` librewolf-unwrapped: 154.0-2 -> 154.0.1-2 ``                                                 |
| [`cd325b49`](https://github.com/NixOS/nixpkgs/commit/cd325b49aed9c6ec04a0e1d1b73bd31e5b92fd9a) | `` nixos/tests: fix Kaidan ``                                                                   |
| [`769c73a7`](https://github.com/NixOS/nixpkgs/commit/769c73a7e4d8e908e737d4f708a0e08ad2b47fd6) | `` trailbase: use GitHub releases for update script ``                                          |
| [`a759c6fb`](https://github.com/NixOS/nixpkgs/commit/a759c6fb26b30585478a7f2351d2683f3d384ffa) | `` multiviewer-for-f1: 2.8.3 -> 2.8.4 ``                                                        |
| [`7ffb898b`](https://github.com/NixOS/nixpkgs/commit/7ffb898b735810665b29376775d2cae10cd46f3a) | `` blesh: 0.4.0-devel3-unstable-2026-08-12 -> 0.4.0-devel3-unstable-2026-08-19 ``               |
| [`a5258381`](https://github.com/NixOS/nixpkgs/commit/a5258381b28511c09a3d397388d0aac50c5a0b8a) | `` tcl, tk: Drop leftovers from Tcl/Tk 8.5 ``                                                   |
| [`13369b63`](https://github.com/NixOS/nixpkgs/commit/13369b639888e50645ed13f4e429c43ebdf41756) | `` sandbox-runtime: 0.0.73 -> 0.0.74 ``                                                         |
| [`eea9d917`](https://github.com/NixOS/nixpkgs/commit/eea9d9170e437603a87c61dfeed84851fb565068) | `` snyk: 1.1306.4 -> 1.1307.0 ``                                                                |
| [`3b02625d`](https://github.com/NixOS/nixpkgs/commit/3b02625d8b0fef27d95769a45205d11838a267dc) | `` pgfplots: 1.18.2 -> 1.18.3 ``                                                                |
| [`55595dc1`](https://github.com/NixOS/nixpkgs/commit/55595dc1fac57c21ec736165725b79285c3aa7ba) | `` taproot-assets: 0.8.1 -> 0.8.2 ``                                                            |
| [`e3e5d029`](https://github.com/NixOS/nixpkgs/commit/e3e5d0293d7296152fc81c04f7a8c22b739d2d4f) | `` python3Packages.urlscan-python: migrate to finalAttrs ``                                     |
| [`14bc0ffb`](https://github.com/NixOS/nixpkgs/commit/14bc0ffbb96617b9d5de37f5c7d79bb005d6f2d0) | `` python3Packages.urlscan-python: 0.0.1 -> 2026.08.18 ``                                       |
| [`b57db9f9`](https://github.com/NixOS/nixpkgs/commit/b57db9f9366dbd057ce03737747752ea25b4c81d) | `` music-assistant-desktop: 0.6.3 -> 0.6.5 ``                                                   |
| [`9916b37b`](https://github.com/NixOS/nixpkgs/commit/9916b37b031288c9e16cdec83dcd71bed745c26a) | `` ostui: 1.3.6 -> 1.3.8 ``                                                                     |
| [`bab241b6`](https://github.com/NixOS/nixpkgs/commit/bab241b677c78ada07cc54bd66895ed57c0e78fc) | `` nodejs_26: 26.7.0 -> 26.8.0 ``                                                               |
| [`09511729`](https://github.com/NixOS/nixpkgs/commit/0951172917a1960c123949fca88b9be3d4411ddc) | `` python3Packages.aioshelly: 13.29.0 -> 13.32.0 ``                                             |
| [`93764d8d`](https://github.com/NixOS/nixpkgs/commit/93764d8d975b268987e10a679292fe15bf427249) | `` audiness: 1.0.1 -> 1.1.0 ``                                                                  |
| [`70f741d7`](https://github.com/NixOS/nixpkgs/commit/70f741d7722cf796d749ce8fec91f97aaa31c5af) | `` rocqPackages.relation-algebra: 1.8.1 → 1.9.0 ``                                              |
| [`78e9ddde`](https://github.com/NixOS/nixpkgs/commit/78e9ddde2f3bbabe94f566d7439c05e21356e169) | `` rocqPackages.relation-algebra: 1.8.0 → 1.8.1 ``                                              |
| [`c6f8c197`](https://github.com/NixOS/nixpkgs/commit/c6f8c197b76de3005f43402feb4c7d08eb19b09d) | `` python3Packages.pytenable: add arrow ``                                                      |
| [`5ebc3d65`](https://github.com/NixOS/nixpkgs/commit/5ebc3d65955b1e261164193f5ee7a8ccfebd29a9) | `` fvm: refactor ``                                                                             |
| [`23ed1b19`](https://github.com/NixOS/nixpkgs/commit/23ed1b19fb72ba61439f1e46df129a4e335f6980) | `` fvm: 4.1.2 -> 4.3.0 ``                                                                       |
| [`9beef53f`](https://github.com/NixOS/nixpkgs/commit/9beef53fe5a4d76cb62542c19585d9c4b7e35baa) | `` xssearch: 0.1.9 -> 0.2.0 ``                                                                  |
| [`6528392a`](https://github.com/NixOS/nixpkgs/commit/6528392a172b80e65bdf4739ab40a4c9feddf285) | `` sstorytime: 0-unstable-2026-08-12 -> 1.0-beta-unstable-2026-08-20 ``                         |
| [`e7fcc65c`](https://github.com/NixOS/nixpkgs/commit/e7fcc65c317afb32e185c4e5fab5e146c09bee57) | `` python3Packages.restfly: migrate to finalAttrs ``                                            |
| [`49deaca9`](https://github.com/NixOS/nixpkgs/commit/49deaca93f4a6c8207fc936d0768e105dd2d2767) | `` python3Packages.restfly: 1.5.1 -> 2.0.3 ``                                                   |
| [`8b71260e`](https://github.com/NixOS/nixpkgs/commit/8b71260e1fb26ace399e252cafd22ebd8c0306ff) | `` python3Packages.pydantic-xml: init at 2.21.1 ``                                              |
| [`a796bf69`](https://github.com/NixOS/nixpkgs/commit/a796bf69e2972af02ea01e8a23385c896564fcb4) | `` fd: 10.4.2 -> 10.5.0 ``                                                                      |
| [`7e34beb6`](https://github.com/NixOS/nixpkgs/commit/7e34beb6ab0f10be46e38c58ab042b89e28a8f5e) | `` python3Packages.asyncwhois: 1.1.13 -> 1.1.14 ``                                              |
| [`67f72a36`](https://github.com/NixOS/nixpkgs/commit/67f72a36c886caa0eeb9225601d8dcea9ac67194) | `` python3Packages.aiovodafone: 3.3.1 -> 3.3.2 ``                                               |
| [`a96a6686`](https://github.com/NixOS/nixpkgs/commit/a96a6686970e690969c2a835856dfe78c6ec8eab) | `` python3Packages.alibabacloud-cs20151215: 7.1.1 -> 7.1.3 ``                                   |
| [`25faedc9`](https://github.com/NixOS/nixpkgs/commit/25faedc979961c1bd6a2f5a96c7f5c5220c38b56) | `` python3Packages.alibabacloud-ecs20140526: 7.9.6 -> 7.10.0 ``                                 |
| [`9cb64b2a`](https://github.com/NixOS/nixpkgs/commit/9cb64b2a8ea0116167deab796d592972c188b805) | `` python3Packages.cpe-search: 0.2.9 -> 0.2.11 ``                                               |
| [`f6b5d13b`](https://github.com/NixOS/nixpkgs/commit/f6b5d13b2328b883c3f79e35abdd716e47668dea) | `` python3Packages.fastapi-mail: 1.6.5 -> 1.6.8 ``                                              |
| [`a6874d95`](https://github.com/NixOS/nixpkgs/commit/a6874d95362fae5d6759e2f41d2130185b20cb80) | `` python3Packages.nettigo-air-monitor: migrate to finalAttrs ``                                |
| [`5bff2f64`](https://github.com/NixOS/nixpkgs/commit/5bff2f645aba96733f829eb0b93c508dd5781365) | `` python3Packages.nettigo-air-monitor: migrate to pyprojectVersionPatchHook ``                 |
| [`bcad759e`](https://github.com/NixOS/nixpkgs/commit/bcad759e6a06e14a07da3e80d75d75f7bc5ff57d) | `` python3Packages.nettigo-air-monitor: 5.0.0 -> 5.1.0 ``                                       |
| [`84b80791`](https://github.com/NixOS/nixpkgs/commit/84b80791993f87ba80929ed38b94456a00996da4) | `` python3Packages.ngff-zarr: 0.42.1 -> 0.43.0 ``                                               |
| [`3a7ccfd6`](https://github.com/NixOS/nixpkgs/commit/3a7ccfd64f11ed0ed3d0c178c9429128c67c896e) | `` entire: 0.10.0 -> 0.10.2 ``                                                                  |
| [`2fa7b100`](https://github.com/NixOS/nixpkgs/commit/2fa7b1004e848b3a2cd41509cd9884fb256733bd) | `` pitchfork: init at 2.23.0 ``                                                                 |
| [`cc451ffb`](https://github.com/NixOS/nixpkgs/commit/cc451ffb44b500d6b836c27855ca49a9c2f59170) | `` libmateweather: remove unnecessary deletion of icon-theme.cache ``                           |
| [`7504fecc`](https://github.com/NixOS/nixpkgs/commit/7504fecc91f97c060b5129610d11c032ea07dbc3) | `` ocamlformat-mlx: remove minimalOcamlVersion ``                                               |
| [`15e2a365`](https://github.com/NixOS/nixpkgs/commit/15e2a36584dd5463052bf5bdd0a3f5cc8febc66f) | `` vscode-extensions.ocamlpro.superbol: init at 1.0.0 ``                                        |
| [`c907f845`](https://github.com/NixOS/nixpkgs/commit/c907f84567e46827952a88f8cd19221514b1b7a9) | `` vscode-extensions.jacqueslucke.gcov-viewer: init at 0.6.0 ``                                 |
| [`f0d23b4d`](https://github.com/NixOS/nixpkgs/commit/f0d23b4df3b65da1c60d84aa10b5537d5a43c6f6) | `` ocamlPackages.superbol-studio-oss: init at 1.0.0 ``                                          |
| [`89b6c3a4`](https://github.com/NixOS/nixpkgs/commit/89b6c3a4afa3e5757e84788d29ba8123be7f2642) | `` gnucobol: clean up and fix darwin build ``                                                   |
| [`88de0c3b`](https://github.com/NixOS/nixpkgs/commit/88de0c3bf45970f8d9cd071d2a9bf082f5abc6ec) | `` ocamlPackages.goblint-cil: init at 2.1.1 ``                                                  |
| [`1c4e6851`](https://github.com/NixOS/nixpkgs/commit/1c4e6851bfe8aa64a51a5ed359821ec78f2a2d39) | `` ocamlPackages.autofonce: init at 0.9-unstable-2026-06-25 ``                                  |
| [`b4d58d86`](https://github.com/NixOS/nixpkgs/commit/b4d58d866e52f1bebc8cc9ed2f6a9a54fd299b92) | `` ocamlPackages.drom: init at 0.9.3 ``                                                         |
| [`a1b255ef`](https://github.com/NixOS/nixpkgs/commit/a1b255efb5679ac288a4618318d86c3f3f5320c6) | `` ocamlPackages.ez_opam_file: init at 0.1.0 ``                                                 |
| [`f908985a`](https://github.com/NixOS/nixpkgs/commit/f908985af668eaae4f8ac3a4da963cc7bc1559d7) | `` ocamlPackages.ez_file: init at 0.5.0 ``                                                      |
| [`003a35a2`](https://github.com/NixOS/nixpkgs/commit/003a35a222f3564a65c1ec5d5ba6666a051c24a3) | `` ocamlPackages.ez_cmdliner: init at 0.5.0 ``                                                  |
| [`15865553`](https://github.com/NixOS/nixpkgs/commit/15865553cb97c4d1f9a74a1885722db78c23dbad) | `` ocamlPackages.ez_subst: init at 0.2.1 ``                                                     |
| [`1f815265`](https://github.com/NixOS/nixpkgs/commit/1f815265573dd8161a2a745cd40f3617e2936981) | `` ocamlPackages.ppx_protocol_conv: init at 5.2.3 ``                                            |
| [`bb5fa677`](https://github.com/NixOS/nixpkgs/commit/bb5fa6774d8c96337cbacb13230dc92eeff424a4) | `` ocamlPackages.ppx_deriving_encoding: init at 0.4.2 ``                                        |
| [`eaec534a`](https://github.com/NixOS/nixpkgs/commit/eaec534a0244b26019a809b10a583d213d25a6eb) | `` ocamlPackages.jsonoo: init at 0.3.0 ``                                                       |
| [`a5ac9975`](https://github.com/NixOS/nixpkgs/commit/a5ac99750f0388277a619fe48315df718c0000cf) | `` ocamlPackages.ocplib_stuff: init at 0.4.0 ``                                                 |
| [`b21e07a3`](https://github.com/NixOS/nixpkgs/commit/b21e07a39601f68d9eb6c554f3af2aaf7a2207b5) | `` ocamlPackages.ez_api: init at 3.0.0 ``                                                       |
| [`dc8b7346`](https://github.com/NixOS/nixpkgs/commit/dc8b7346f15af6e8bb62f3423a8973fb1b09300d) | `` stalwart-vandelay: 1.0.8 -> 1.0.9 ``                                                         |
| [`7cecd86e`](https://github.com/NixOS/nixpkgs/commit/7cecd86e55bbfad44524c4d96c461ea881825c58) | `` fq: install man page ``                                                                      |
| [`42926fe7`](https://github.com/NixOS/nixpkgs/commit/42926fe71e267e459c9a06c8bdcb392f8ddf36d4) | `` chromium,chromedriver: 151.0.7922.173 -> 152.0.7977.64 ``                                    |
| [`faa1dad9`](https://github.com/NixOS/nixpkgs/commit/faa1dad9d404db4d59a00c216f68363811da2e7e) | `` opencloud: 7.4.0 -> 7.5.0 ``                                                                 |
| [`8bbf224c`](https://github.com/NixOS/nixpkgs/commit/8bbf224c8701d78b7c67520f8fa57a59915a7758) | `` opencloud.web: 7.3.0 -> 7.4.0 ``                                                             |
| [`3f3e686c`](https://github.com/NixOS/nixpkgs/commit/3f3e686c42db7875c9b8a6f43eca9ff1197b1307) | `` lasuite-meet: 1.28.0 -> 1.29.0 ``                                                            |
| [`5e35af53`](https://github.com/NixOS/nixpkgs/commit/5e35af53ed25dcccb751a5add6ca806b2f0dc779) | `` prisma_7, prisma-engines_7: 7.9.1 -> 7.10.0 ``                                               |
| [`23484004`](https://github.com/NixOS/nixpkgs/commit/23484004f128eecf7a0a27e2414e7665de348dc6) | `` ytdownloader: 3.22.0 -> 4.0.1, electron_41 -> electron_43 ``                                 |
| [`17bfb6b1`](https://github.com/NixOS/nixpkgs/commit/17bfb6b19606f4f9927217a250836bc95f9467ab) | `` feishin: clean up ``                                                                         |
| [`9db57822`](https://github.com/NixOS/nixpkgs/commit/9db57822fd10ea69930770e29b9b714af4fb8eb5) | `` pkgsStatic.shishi: fix build ``                                                              |
| [`672965b7`](https://github.com/NixOS/nixpkgs/commit/672965b71d4115da725ba3571554b8a938396ee1) | `` shishi: reformat with "nixfmt -s" ``                                                         |
| [`4b374356`](https://github.com/NixOS/nixpkgs/commit/4b374356a644aa37514417363e58f220af6dd8d2) | `` feishin: bump electron to v43 ``                                                             |
| [`fd9f0545`](https://github.com/NixOS/nixpkgs/commit/fd9f0545b45c5a2967cbcfb93016b7ccdd5e77c9) | `` writedisk: 1.3.0 -> 1.5.0 ``                                                                 |
| [`2f364bf6`](https://github.com/NixOS/nixpkgs/commit/2f364bf6308286fc9665d8ef6c5796e014d006f8) | `` npb: init at 1.0.0 ``                                                                        |
| [`fa0ab2e5`](https://github.com/NixOS/nixpkgs/commit/fa0ab2e5e7df66451dd1791cbc840dd32137e6bf) | `` qui: 1.25.0 -> 1.26.0 ``                                                                     |
| [`c8c3394d`](https://github.com/NixOS/nixpkgs/commit/c8c3394d56533f9faa48d773c29e9635020fc3d0) | `` babashka: Don't set DEPS_CLJ_TOOLS_DIR in wrapper ``                                         |
| [`56091ca6`](https://github.com/NixOS/nixpkgs/commit/56091ca6fee64cbbc74c41f63ab655ba0f6e5d69) | `` haskell.compiler.ghc966DebianBinary: add loongarch64-linux support ``                        |
| [`d4e8fcc6`](https://github.com/NixOS/nixpkgs/commit/d4e8fcc63058392d38d2c047241a6b8b97ad4844) | `` sage: fix tests with gfan 0.8beta ``                                                         |
| [`081152f7`](https://github.com/NixOS/nixpkgs/commit/081152f7ce96d9ce8ba903c7d48c9f320087c426) | `` maintainers: update _0k4r1m ``                                                               |
| [`2f7cc4a5`](https://github.com/NixOS/nixpkgs/commit/2f7cc4a5a49fb1dac95c3600e67d45ff923d9e68) | `` lxmf-rs: don't build and install xtask ``                                                    |
| [`fc632e48`](https://github.com/NixOS/nixpkgs/commit/fc632e4800e143d1a573387839676ffbfd93e391) | `` gitcomet: clean up expression and add longDescription ``                                     |
| [`5f10a498`](https://github.com/NixOS/nixpkgs/commit/5f10a498658c69c0e1ea8a01f5ac9816d212f162) | `` python3Packages.reactivex: 4.1.0 -> 5.1.0 ``                                                 |
| [`7616c71b`](https://github.com/NixOS/nixpkgs/commit/7616c71b4cbaec40f89541d46ce4217d04af67a6) | `` python3Packages.pypck: 0.9.14 -> 0.9.15a3 ``                                                 |
| [`5bc05f71`](https://github.com/NixOS/nixpkgs/commit/5bc05f71b5e77ad085563c715c301882b377ee05) | `` labwc-menu-generator: 0.2.0-unstable-2026-08-15 -> 0.2.0-unstable-2026-08-21 ``              |
| [`53a8591a`](https://github.com/NixOS/nixpkgs/commit/53a8591a4e4fc32c3f4f20cfb265164191565b56) | `` wapiti: 3.3.1 -> 3.3.2 ``                                                                    |
| [`7c56a83f`](https://github.com/NixOS/nixpkgs/commit/7c56a83fc107a0c320dd6ae067238f61fd2e407e) | `` wpprobe: 0.12.7 -> 0.12.11 ``                                                                |
| [`2023145b`](https://github.com/NixOS/nixpkgs/commit/2023145ba3bc0826f41efae58052bf145e51f7dd) | `` picgo: 3.0.1 -> 3.0.2 ``                                                                     |
| [`a48a82b5`](https://github.com/NixOS/nixpkgs/commit/a48a82b53f937f9cb9efb06c32b47f1556ee177e) | `` vacuum-go: 0.30.0 -> 0.30.1 ``                                                               |
| [`8895fe2e`](https://github.com/NixOS/nixpkgs/commit/8895fe2edfa39e43615ce32d13020770540dc909) | `` tree-sitter-grammars.tree-sitter-ebnf: 0-unstable-2023-02-06 -> 0.1.1-unstable-2023-02-06 `` |
| [`4f8a14c7`](https://github.com/NixOS/nixpkgs/commit/4f8a14c7493e5263c86b85cc90046967cc8e3ccc) | `` python3Packages.tencentcloud-sdk-python: 3.1.164 -> 3.1.165 ``                               |
| [`961f77eb`](https://github.com/NixOS/nixpkgs/commit/961f77ebedb23da1b0cd778149de921511e1fa47) | `` python3Packages.iamdata: 0.1.202608251 -> 0.1.202608261 ``                                   |
| [`3b91729b`](https://github.com/NixOS/nixpkgs/commit/3b91729befbf65caf5e181240d4cc11cd8053017) | `` tree-sitter-grammars.tree-sitter-tql: 1.1.0 -> 1.2.0 ``                                      |
| [`c043b3ba`](https://github.com/NixOS/nixpkgs/commit/c043b3ba3823f6925e7e7d21b058768d6fd3ebd1) | `` tree-sitter-grammars.tree-sitter-systemverilog: 0.3.1 -> 0.4.0 ``                            |
| [`110b9bb2`](https://github.com/NixOS/nixpkgs/commit/110b9bb2be4714a3f9ef70cc789a192e3bb35329) | `` tree-sitter-grammars.tree-sitter-ssh-client-config: 2026.7.9 -> 2026.8.20 ``                 |
| [`3cd2009c`](https://github.com/NixOS/nixpkgs/commit/3cd2009cf665c5b3e206c9eb4ef48c1ec1022098) | `` talhelper: 3.1.16 -> 3.1.17 ``                                                               |
| [`7bf91d84`](https://github.com/NixOS/nixpkgs/commit/7bf91d8431f827508182e15eb92f32404f175a8e) | `` weasis: 4.7.2 -> 4.7.3 ``                                                                    |
| [`7006d439`](https://github.com/NixOS/nixpkgs/commit/7006d439bdd8b9665b97101c14cb4060fe21f0ca) | `` google-chat-linux: 5.39.26-1 -> 5.39.27-1 ``                                                 |
| [`3c611eba`](https://github.com/NixOS/nixpkgs/commit/3c611ebacec08abd894297c255b05a045bebc67b) | `` usage: 5.1.0 -> 6.4.1 ``                                                                     |
| [`1bee4a4f`](https://github.com/NixOS/nixpkgs/commit/1bee4a4f0fb214dd441c09984ddd4d2ad5538a20) | `` Revert "cups: add `doc` output" ``                                                           |
| [`692f9fbd`](https://github.com/NixOS/nixpkgs/commit/692f9fbd60a5a1758ba4f686ccca5dfa431fb478) | `` python3Packages.hatch-gettext: 1.1.1 -> 1.1.2 ``                                             |
| [`bfdf25de`](https://github.com/NixOS/nixpkgs/commit/bfdf25deef7ea6ce4cca533262334ac431cf412a) | `` python3Packages.hatch-argparse-manpage: 1.0.1 -> 1.0.2 ``                                    |
| [`b76e00df`](https://github.com/NixOS/nixpkgs/commit/b76e00dfdd452073b276af5ace43593704ca8dd2) | `` release-unfree-redistributable: disable cuda support and filter any cuda/nvidia matches ``   |
| [`3b3e7da0`](https://github.com/NixOS/nixpkgs/commit/3b3e7da0db9e47fedbb066d83df49eae70a6d527) | `` todoist-cli: 3.1.8 -> 3.3.2 ``                                                               |
| [`4bad2c4f`](https://github.com/NixOS/nixpkgs/commit/4bad2c4fe007a71d5961ded0f265ce16a9e15710) | `` cargo-swift: 0.11.0 -> 0.11.1 ``                                                             |
| [`be713628`](https://github.com/NixOS/nixpkgs/commit/be7136282d3dab31e3192dde0478d62b6fa8dbc7) | `` niri-sidebar: init at 0.4.0 ``                                                               |
| [`55a9ca26`](https://github.com/NixOS/nixpkgs/commit/55a9ca269cae9b16a276cd422cd5f7d13ff43724) | `` szurubooru: 2.5-unstable-2025-07-19 -> 2.5-unstable-2026-07-25 ``                            |
| [`bc8bdb46`](https://github.com/NixOS/nixpkgs/commit/bc8bdb46dd4ceac78970f8bc47f4876287da6e22) | `` go-tools: 2026.2 -> 2026.2.1 ``                                                              |
| [`0a4b88db`](https://github.com/NixOS/nixpkgs/commit/0a4b88db877ddedbbe8157a7a28caa15c69cc166) | `` rasm: 3.2.6 -> 3.2.7 ``                                                                      |
| [`bb3bae30`](https://github.com/NixOS/nixpkgs/commit/bb3bae30a7647b3b8c3f8613e5acdb80f553d67b) | `` traccar: 6.13.3 -> 6.15.2 ``                                                                 |
| [`a63a6091`](https://github.com/NixOS/nixpkgs/commit/a63a609103451ca140147cd9ce5402db40159128) | `` yopass: init at 14.9.0 ``                                                                    |
| [`743f4d1e`](https://github.com/NixOS/nixpkgs/commit/743f4d1e4728aa34aa1d8d56f256773afe95ab3b) | `` fscan: 2.2.0 -> 2.2.1 ``                                                                     |
| [`33b6cb8c`](https://github.com/NixOS/nixpkgs/commit/33b6cb8c73180bab1791e477cda41621312d06bc) | `` alembic: fix reference cycle on darwin ``                                                    |
| [`a2f125b0`](https://github.com/NixOS/nixpkgs/commit/a2f125b071ec157b483daa4fee051fae543b0fba) | `` home-assistant-custom-components.battery_notes: 3.5.3 -> 3.6.0 ``                            |
| [`e8d37238`](https://github.com/NixOS/nixpkgs/commit/e8d372389fd9bfbd4db6c3be754c216f1c4585bd) | `` pb: 1.0.0 -> 1.0.1 ``                                                                        |
| [`9bf8d588`](https://github.com/NixOS/nixpkgs/commit/9bf8d588df83d84f65300761af88a68f0987fa96) | `` python3Packages.claude-agent-sdk: 0.2.143 -> 0.2.144 ``                                      |
| [`6bb1a443`](https://github.com/NixOS/nixpkgs/commit/6bb1a443582e43ac7110a8c6658e136d3ecf6d0b) | `` matterjs-server: remove temporary build files ``                                             |
| [`04221709`](https://github.com/NixOS/nixpkgs/commit/0422170938a40dad83dce3a773f80df0dd1684c8) | `` panache: 3.4.0 -> 3.6.1 ``                                                                   |

*... and 1158 more commits (truncated)*